### PR TITLE
Default start to ./dcrcli -l

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,6 +68,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	// get an instance of walletrpcclient without connecting
+	// because there are commands we can run at this stage without needing to connect to dcrwallet
+	client := walletrpcclient.New()
+
 	serveHTTP := false
 	if config.HTTPServerAddress != "" {
 		serveHTTP = true
@@ -78,7 +82,6 @@ func main() {
 	if len(args) < 1 && !serveHTTP {
 		//Go to usage page
 		//usage("No command specified")
-		client := walletrpcclient.New()
 		res, err := client.RunCommand("listcommands", nil)
 		if err != nil {
 			// can never happen at this stage
@@ -91,9 +94,6 @@ func main() {
 
 	var command string
 
-	// get an instance of walletrpcclient without connecting
-	// because there are commands we can run at this stage without needing to connect to dcrwallet
-	client := walletrpcclient.New()
 	if !serveHTTP {
 		command = args[0]
 		if args[0] == "listcommands" {

--- a/main.go
+++ b/main.go
@@ -74,10 +74,19 @@ func main() {
 	}
 
 	// check if arguments were supplied
-	// if not, exit
+	// if not, run ./dcrcli -l, previously used to exit and show usage info
 	if len(args) < 1 && !serveHTTP {
-		usage("No command specified")
-		os.Exit(1)
+		//Go to usage page
+		//usage("No command specified")
+		client := walletrpcclient.New()
+		res, err := client.RunCommand("listcommands", nil)
+		if err != nil {
+			// can never happen at this stage
+			fmt.Fprintf(os.Stderr, "Error running command %s'\n", err.Error())
+			os.Exit(1)
+		}
+		printResult(res)
+		os.Exit(0)
 	}
 
 	var command string


### PR DESCRIPTION
If no arguments are passed it will default to listcommands output.

Fixes #18