### PR TITLE
add nextaccount functionality to walletrpcclient, cli

### DIFF
--- a/cli/getPassword.go
+++ b/cli/getPassword.go
@@ -1,0 +1,79 @@
+// License: MIT Open Source
+// Copyright (c) Joe Linoff 2016
+// Go code to prompt for password using only standard packages by utilizing syscall.ForkExec() and syscall.Wait4().
+// Correctly resets terminal echo after ^C interrupts.
+
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+)
+
+// getPassword - Prompt for password.
+func getPassword(prompt string) (string, error) {
+	fmt.Println(prompt)
+
+	// Catch a ^C interrupt.
+	// Make sure that we reset term echo before exiting.
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel, os.Interrupt)
+	go func() {
+		for _ = range signalChannel {
+			fmt.Println("\n^C interrupt.")
+			termEcho(true)
+			os.Exit(1)
+		}
+	}()
+
+	// disable terminal echo
+	termEcho(false)
+
+	// Echo is disabled, now grab the data.
+	reader := bufio.NewReader(os.Stdin)
+	text, err := reader.ReadString('\n')
+
+	// re-enable terminal echo
+	termEcho(true)
+	fmt.Println("")
+
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(text), nil
+}
+
+// techEcho() - turns terminal echo on or off.
+func termEcho(on bool) {
+	// Common settings and variables for both stty calls.
+	attrs := syscall.ProcAttr{
+		Dir:   "",
+		Env:   []string{},
+		Files: []uintptr{os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd()},
+		Sys:   nil}
+	var ws syscall.WaitStatus
+	cmd := "echo"
+	if on == false {
+		cmd = "-echo"
+	}
+
+	// Enable/disable echoing.
+	pid, err := syscall.ForkExec(
+		"/bin/stty",
+		[]string{"stty", cmd},
+		&attrs)
+	if err != nil {
+		panic(err)
+	}
+
+	// Wait for the stty process to complete.
+	_, err = syscall.Wait4(pid, &ws, 0, nil)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/raedahgroup/dcrcli
 
 require (
-	github.com/Baozisoftware/qrcode-terminal-go v0.0.0-20170407111555-c0650d8dff0f // indirect
+	github.com/Baozisoftware/qrcode-terminal-go v0.0.0-20170407111555-c0650d8dff0f
 	github.com/btcsuite/go-flags v0.0.0-20150116065318-6c288d648c1c
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/decred/dcrd/dcrutil v1.1.1
@@ -9,11 +9,11 @@ require (
 	github.com/golang/protobuf v1.2.0 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
 	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a // indirect
-	github.com/manifoldco/promptui v0.3.1 // indirect
+	github.com/manifoldco/promptui v0.3.1
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/raedahgroup/dcrcli/walletrpcclient v0.0.1
-	github.com/skip2/go-qrcode v0.0.0-20171229120447-cf5f9fa2f0d8 // indirect
+	github.com/skip2/go-qrcode v0.0.0-20171229120447-cf5f9fa2f0d8
 	golang.org/x/sys v0.0.0-20180928133829-e4b3c5e90611 // indirect
 	google.golang.org/genproto v0.0.0-20180928223349-c7e5094acea1 // indirect
 	google.golang.org/grpc v1.14.0

--- a/walletrpcclient/walletrpcclient.go
+++ b/walletrpcclient/walletrpcclient.go
@@ -184,3 +184,17 @@ func (c *Client) ValidateAddress(address string) (bool, error) {
 
 	return r.IsValid, nil
 }
+
+func (c *Client) NextAccount(accountName string, passphrase string) (uint32, error) {
+	req := &pb.NextAccountRequest{
+		AccountName:accountName,
+		Passphrase:[]byte(passphrase),
+	}
+
+	r, err := c.walletServiceClient.NextAccount(context.Background(), req)
+	if err != nil {
+		return 0, err
+	}
+
+	return r.AccountNumber, nil
+}


### PR DESCRIPTION
I've not added this functionality to http server yet.
From cli, `dcrcli nextaccount "Account Name"`

I'll have to work on the error it returns when the account name argument is missing. I'll do that in a separate PR as it also affects the message displayed when using `dcrcli receive` without an account number argument.