### PR TITLE
convert send amount from dcr unit to atom in walletrpcclient

### DIFF
--- a/cli/helpers.go
+++ b/cli/helpers.go
@@ -72,12 +72,12 @@ func getSendDestinationAddress(c *walletrpcclient.Client) (string, error) {
 	return address, nil
 }
 
-func getSendAmount() (int64, error) {
-	var amount int64
+func getSendAmount() (float64, error) {
+	var amount float64
 	var err error
 
 	validateAmount := func(input string) error {
-		amount, err = strconv.ParseInt(input, 10, 64)
+		amount, err = strconv.ParseFloat(input, 64)
 		if err != nil {
 			return fmt.Errorf("error parsing amount: %s", err.Error())
 		}

--- a/walletrpcclient/walletrpcclient.go
+++ b/walletrpcclient/walletrpcclient.go
@@ -59,7 +59,15 @@ func (c *Client) connect(address, cert string, noTLS bool) (*grpc.ClientConn, er
 	return conn, nil
 }
 
-func (c *Client) Send(amount int64, sourceAccount uint32, destinationAddress, passphrase string) (*SendResult, error) {
+func (c *Client) Send(amountInDCR float64, sourceAccount uint32, destinationAddress, passphrase string) (*SendResult, error) {
+	// convert amount from float64 DCR to int64 Atom as required by dcrwallet ConstructTransaction implementation
+	amountInAtom, err := dcrutil.NewAmount(amountInDCR)
+	if err != nil {
+		return nil, err
+	}
+	// type of amountInAtom is `dcrutil.Amount` which is an int64 alias
+	amount := int64(amountInAtom)
+
 	// decode destination address
 	addr, err := dcrutil.DecodeAddress(destinationAddress)
 	if err != nil {

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -43,7 +43,7 @@ func (s *Server) PostSend(res http.ResponseWriter, req *http.Request) {
 	destinationAddressStr := req.FormValue("destinationAddress")
 	passphraseStr := req.FormValue("walletPassphrase")
 
-	amount, err := strconv.ParseInt(amountStr, 10, 64)
+	amount, err := strconv.ParseFloat(amountStr, 64)
 	if err != nil {
 		data["error"] = err.Error()
 		return
@@ -55,7 +55,7 @@ func (s *Server) PostSend(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	result, err := s.walletClient.Send(amount*100000000, uint32(sourceAccount), destinationAddressStr, passphraseStr)
+	result, err := s.walletClient.Send(amount, uint32(sourceAccount), destinationAddressStr, passphraseStr)
 	if err != nil {
 		data["error"] = err.Error()
 		return


### PR DESCRIPTION
Modified the `cli` and `web` packages to accept float64 amounts (fractional DCR amounts). While the core `walletrpcclient` package accepts this float64 amount value, it recognizes that what `dcrwallet` actually needs is the equivalent amount in Atoms (int64), so the `walletrpcclient` package converts the DCR amount to Atoms before passing to `dcrwallet` rpc.

Closes #37 