### PR TITLE
use default http server address

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	defaultConfigFilename = "dcrcli.conf"
-	defaultLogDirname     = "log"
-	defaultLogFilename    = "dcrcli.log"
+	defaultConfigFilename    = "dcrcli.conf"
+	defaultLogDirname        = "log"
+	defaultLogFilename       = "dcrcli.log"
+	defaultHTTPServerAddress = "127.0.0.1:1234"
 )
 
 var (
@@ -100,9 +101,11 @@ func addParserSettings(parser *flags.Parser) {
 }
 
 func loadConfig(appName string) (*config, []string, error) {
+	// load defaults first
 	cfg := config{
-		ConfigFile: defaultConfigFile,
-		RPCCert:    defaultRPCCertFile,
+		ConfigFile:        defaultConfigFile,
+		RPCCert:           defaultRPCCertFile,
+		HTTPServerAddress: defaultHTTPServerAddress,
 	}
 	// Pre-parse command line arguments
 	preCfg := cfg

--- a/main.go
+++ b/main.go
@@ -59,11 +59,6 @@ func main() {
 }
 
 func enterHttpMode(config *config) {
-	if config.HTTPServerAddress == "" {
-		fmt.Println("Cannot start http server. Server address not set")
-		os.Exit(1)
-	}
-
 	client, err := walletrpcclient.New(config.WalletRPCServer, config.RPCCert, config.NoDaemonTLS)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error connecting to RPC server")


### PR DESCRIPTION
default http server address is `127.0.0.1:1234`, can be overwritten in config file or passing `serveraddress` option to `dcrcli`

fixes #56 