### PR TITLE
Updates send and receive outputs

### DIFF
--- a/cli/commands/helpers.go
+++ b/cli/commands/helpers.go
@@ -66,7 +66,11 @@ func getSendDestinationAddress(wallet walletcore.Wallet) (string, error) {
 		}
 
 		if !isValid {
-			return errors.New("invalid address")
+			if (address == "") {
+				return errors.New("You did not specify an address.")
+			}
+
+			return errors.New("That is not a valid address. Try again.")
 		}
 		return nil
 	}
@@ -88,6 +92,10 @@ func getSendAmount() (float64, error) {
 	validateAmount := func(input string) error {
 		amount, err = strconv.ParseFloat(input, 64)
 		if err != nil {
+			if (input == "") {
+				return errors.New("That is did a valid amount. Try again.")
+			}
+
 			return fmt.Errorf("error parsing amount: %s", err.Error())
 		}
 		return nil

--- a/cli/commands/helpers.go
+++ b/cli/commands/helpers.go
@@ -60,16 +60,16 @@ func selectAccount(wallet walletcore.Wallet) (uint32, error) {
 // getSendDestinationAddress fetches the destination address to send DCRs to from the user.
 func getSendDestinationAddress(wallet walletcore.Wallet) (string, error) {
 	validateAddressInput := func(address string) error {
-		isValid, err := wallet.ValidateAddress(address)
+		if (address == "") {
+			return errors.New("You did not specify an address. Try again.")
+		}
+		
+		isValid, err := c.IsAddressValid(address)
 		if err != nil {
 			return fmt.Errorf("error validating address: %s", err.Error())
 		}
 
 		if !isValid {
-			if (address == "") {
-				return errors.New("You did not specify an address. Try again.")
-			}
-
 			return errors.New("That is not a valid address. Try again.")
 		}
 		return nil
@@ -90,12 +90,12 @@ func getSendAmount() (float64, error) {
 	var err error
 
 	validateAmount := func(input string) error {
+		if (input == "") {
+			return errors.New("That is did a valid amount. Try again.")
+		}
+
 		amount, err = strconv.ParseFloat(input, 64)
 		if err != nil {
-			if (input == "") {
-				return errors.New("That is did a valid amount. Try again.")
-			}
-
 			return fmt.Errorf("error parsing amount: %s", err.Error())
 		}
 		return nil

--- a/cli/commands/helpers.go
+++ b/cli/commands/helpers.go
@@ -67,7 +67,7 @@ func getSendDestinationAddress(wallet walletcore.Wallet) (string, error) {
 
 		if !isValid {
 			if (address == "") {
-				return errors.New("You did not specify an address.")
+				return errors.New("You did not specify an address. Try again.")
 			}
 
 			return errors.New("That is not a valid address. Try again.")

--- a/cli/commands/helpers.go
+++ b/cli/commands/helpers.go
@@ -60,11 +60,11 @@ func selectAccount(wallet walletcore.Wallet) (uint32, error) {
 // getSendDestinationAddress fetches the destination address to send DCRs to from the user.
 func getSendDestinationAddress(wallet walletcore.Wallet) (string, error) {
 	validateAddressInput := func(address string) error {
-		if (address == "") {
+		if address == "" {
 			return errors.New("You did not specify an address. Try again.")
 		}
 
-		isValid, err := c.IsAddressValid(address)
+		isValid, err := wallet.ValidateAddress(address)
 		if err != nil {
 			return fmt.Errorf("error validating address: %s", err.Error())
 		}
@@ -90,8 +90,8 @@ func getSendAmount() (float64, error) {
 	var err error
 
 	validateAmount := func(input string) error {
-		if (input == "") {
-			return errors.New("That is did a valid amount. Try again.")
+		if input == "" {
+			return errors.New("You did not specify an amount. Try again.")
 		}
 
 		amount, err = strconv.ParseFloat(input, 64)

--- a/cli/commands/helpers.go
+++ b/cli/commands/helpers.go
@@ -63,7 +63,7 @@ func getSendDestinationAddress(wallet walletcore.Wallet) (string, error) {
 		if (address == "") {
 			return errors.New("You did not specify an address. Try again.")
 		}
-		
+
 		isValid, err := c.IsAddressValid(address)
 		if err != nil {
 			return fmt.Errorf("error validating address: %s", err.Error())

--- a/cli/commands/helpers.go
+++ b/cli/commands/helpers.go
@@ -96,7 +96,7 @@ func getSendAmount() (float64, error) {
 
 		amount, err = strconv.ParseFloat(input, 64)
 		if err != nil {
-			return fmt.Errorf("error parsing amount: %s", err.Error())
+			return fmt.Errorf("Invalid amount. Try again")
 		}
 		return nil
 	}

--- a/cli/commands/receive.go
+++ b/cli/commands/receive.go
@@ -61,7 +61,7 @@ func (receiveCommand ReceiveCommand) Run(ctx context.Context, wallet walletcore.
 		}
 	}
 
-	confirm, err := terminalprompt.RequestInput("Would you like to a generate QR code? (y/N) ", validateConfirm)
+	confirm, err := terminalprompt.RequestInput("Would you like to generate a QR code? (y/N) ", validateConfirm)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading your response: %s", err.Error())
 		return err

--- a/cli/commands/receive.go
+++ b/cli/commands/receive.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/raedahgroup/godcr/walletrpcclient"
+	"github.com/raedahgroup/godcr/app/walletcore"
+	"github.com/raedahgroup/godcr/cli/runner"
 	"github.com/raedahgroup/godcr/cli/termio/terminalprompt"
 	"github.com/mdp/qrterminal"
 )
@@ -46,7 +47,7 @@ func (receiveCommand ReceiveCommand) Run(ctx context.Context, wallet walletcore.
 	}
 
 	// Print out address as string
-	fmt.Println(receiveResult.Address)
+	fmt.Println(receiveAddress)
 
 	// Print out QR code
 	validateConfirm := func(address string) error {
@@ -60,6 +61,7 @@ func (receiveCommand ReceiveCommand) Run(ctx context.Context, wallet walletcore.
 
 	if confirm == "y" {
 		qrterminal.GenerateHalfBlock("https://github.com/mdp/qrterminal", qrterminal.L, os.Stdout)
+
 	}
 
 	return nil

--- a/cli/commands/receive.go
+++ b/cli/commands/receive.go
@@ -51,10 +51,21 @@ func (receiveCommand ReceiveCommand) Run(ctx context.Context, wallet walletcore.
 	fmt.Println(receiveAddress)
 
 	// Print out QR code
-	validateConfirm := func(address string) error {
-		return nil
+	validateConfirm := func(userResponse string) error {
+		userResponse = strings.TrimSpace(userResponse)
+		userResponse = strings.Trim(userResponse, `"`)
+		if userResponse == "" || strings.EqualFold("Y", userResponse) || strings.EqualFold("n", userResponse) {
+			return nil
+		} else {
+			return fmt.Errorf("invalid option, try again")
+		}
 	}
-	confirm, _ := terminalprompt.RequestInput("Would you like to a generate QR code? (y/N) ", validateConfirm)
+
+	confirm, err := terminalprompt.RequestInput("Would you like to a generate QR code? (y/N) ", validateConfirm)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading your response: %s", err.Error())
+		return err
+	}
 
 	if strings.EqualFold(confirm, "yes") || strings.EqualFold(confirm, "y") {
 		qrterminal.GenerateHalfBlock("https://github.com/mdp/qrterminal", qrterminal.L, os.Stdout)

--- a/cli/commands/receive.go
+++ b/cli/commands/receive.go
@@ -61,7 +61,7 @@ func (receiveCommand ReceiveCommand) Run(ctx context.Context, wallet walletcore.
 		}
 	}
 
-	confirm, err := terminalprompt.RequestInput("Would you like to generate a QR code? (y/N) ", validateConfirm)
+	confirm, err := terminalprompt.RequestInput("Would you like to generate a QR code? (y/N)", validateConfirm)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading your response: %s", err.Error())
 		return err

--- a/cli/commands/receive.go
+++ b/cli/commands/receive.go
@@ -3,10 +3,11 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/raedahgroup/godcr/app/walletcore"
-	"github.com/raedahgroup/godcr/cli/runner"
-	"github.com/raedahgroup/godcr/cli/termio"
-	qrcode "github.com/skip2/go-qrcode"
+	"os"
+
+	"github.com/raedahgroup/godcr/walletrpcclient"
+	"github.com/raedahgroup/godcr/cli/termio/terminalprompt"
+	"github.com/mdp/qrterminal"
 )
 
 // ReceiveCommand generates an address for a user to receive DCR.
@@ -44,21 +45,22 @@ func (receiveCommand ReceiveCommand) Run(ctx context.Context, wallet walletcore.
 		return err
 	}
 
-	qr, err := qrcode.New(receiveAddress, qrcode.Medium)
-	if err != nil {
-		return fmt.Errorf("Error generating QR Code: %s", err.Error())
+	// Print out address as string
+	fmt.Printf("%s\n", receiveResult.Address)
+
+	// Print out QR code
+	validateConfirm := func(address string) error {
+		return  nil
+	}
+	confirm, _ := terminalprompt.RequestInput("Would you like to a generate QR code? (y/n) ", validateConfirm)
+
+	if confirm == "Yes" || confirm == "yes" {
+		confirm = "y"
 	}
 
-	columns := []string{
-		"Address",
-		"QR Code",
+	if confirm == "y" {
+		qrterminal.GenerateHalfBlock("https://github.com/mdp/qrterminal", qrterminal.L, os.Stdout)
 	}
-	rows := [][]interface{}{
-		[]interface{}{
-			receiveAddress,
-			qr.ToString(true),
-		},
-	}
-	termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
+
 	return nil
 }

--- a/cli/commands/receive.go
+++ b/cli/commands/receive.go
@@ -46,7 +46,7 @@ func (receiveCommand ReceiveCommand) Run(ctx context.Context, wallet walletcore.
 	}
 
 	// Print out address as string
-	fmt.Printf("%s\n", receiveResult.Address)
+	fmt.Println(receiveResult.Address)
 
 	// Print out QR code
 	validateConfirm := func(address string) error {

--- a/cli/commands/receive.go
+++ b/cli/commands/receive.go
@@ -67,7 +67,7 @@ func (receiveCommand ReceiveCommand) Run(ctx context.Context, wallet walletcore.
 		return err
 	}
 
-	if strings.EqualFold(confirm, "yes") || strings.EqualFold(confirm, "y") {
+	if strings.EqualFold(confirm, "y") {
 		qrterminal.GenerateHalfBlock("https://github.com/mdp/qrterminal", qrterminal.L, os.Stdout)
 
 	}

--- a/cli/commands/receive.go
+++ b/cli/commands/receive.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/mdp/qrterminal"
 	"github.com/raedahgroup/godcr/app/walletcore"
 	"github.com/raedahgroup/godcr/cli/runner"
 	"github.com/raedahgroup/godcr/cli/termio/terminalprompt"
-	"github.com/mdp/qrterminal"
 )
 
 // ReceiveCommand generates an address for a user to receive DCR.
@@ -51,15 +52,11 @@ func (receiveCommand ReceiveCommand) Run(ctx context.Context, wallet walletcore.
 
 	// Print out QR code
 	validateConfirm := func(address string) error {
-		return  nil
+		return nil
 	}
-	confirm, _ := terminalprompt.RequestInput("Would you like to a generate QR code? (y/n) ", validateConfirm)
+	confirm, _ := terminalprompt.RequestInput("Would you like to a generate QR code? (y/N) ", validateConfirm)
 
-	if confirm == "Yes" || confirm == "yes" {
-		confirm = "y"
-	}
-
-	if confirm == "y" {
+	if strings.EqualFold(confirm, "yes") || strings.EqualFold(confirm, "y") {
 		qrterminal.GenerateHalfBlock("https://github.com/mdp/qrterminal", qrterminal.L, os.Stdout)
 
 	}

--- a/cli/commands/send.go
+++ b/cli/commands/send.go
@@ -3,8 +3,9 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/raedahgroup/godcr/app/walletcore"
-	"github.com/raedahgroup/godcr/cli/runner"
+
+	"github.com/raedahgroup/godcr/walletrpcclient"
+	"github.com/raedahgroup/godcr/cli/termio/terminalprompt"
 )
 
 // SendCommand lets the user send DCR.
@@ -72,7 +73,23 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 		return err
 	}
 
-	var sentTransactionHash string
+	fmt.Printf("You are about to send %f DCR to %s\n", sendAmount, destinationAddress)
+
+	validateConfirm := func(address string) error {
+		return  nil
+	}
+	confirm, _ := terminalprompt.RequestInput("Are you sure? (y/n) ", validateConfirm)
+
+	if confirm == "Yes" || confirm == "yes" {
+		confirm = "y"
+	}
+
+	if confirm != "y" {
+		fmt.Printf("Operation cancelled\n")
+		return  nil
+	}
+
+	var result *walletrpcclient.SendResult
 	if custom {
 		sentTransactionHash, err = wallet.SendFromUTXOs(utxoSelection, sendAmount, sourceAccount, destinationAddress, passphrase)
 	} else {
@@ -83,6 +100,6 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 		return err
 	}
 
-	fmt.Printf("Sent. Txid: %s\n", sentTransactionHash)
+	fmt.Println("sent. txid %s", result.TransactionHash)
 	return nil
 }

--- a/cli/commands/send.go
+++ b/cli/commands/send.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/raedahgroup/godcr/walletrpcclient"
 	"github.com/raedahgroup/godcr/cli/termio/terminalprompt"
@@ -75,16 +76,9 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 
 	fmt.Printf("You are about to send %f DCR to %s\n", sendAmount, destinationAddress)
 
-	validateConfirm := func(address string) error {
-		return  nil
-	}
-	confirm, _ := terminalprompt.RequestInput("Are you sure? (y/n) ", validateConfirm)
+	confirm, _ := terminalprompt.RequestInput("Are you sure? (y/n) ", nil)
 
-	if confirm == "Yes" || confirm == "yes" {
-		confirm = "y"
-	}
-
-	if confirm != "y" {
+	if strings.EqualFold(confirm, "yes") || strings.EqualFold(confirm, "y") {
 		fmt.Printf("Operation cancelled\n")
 		return  nil
 	}

--- a/cli/commands/send.go
+++ b/cli/commands/send.go
@@ -76,18 +76,18 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 		return err
 	}
 
-	fmt.Println("You are about to send %f DCR to %s", sendAmount, destinationAddress)
+	fmt.Printf("You are about to send %f DCR to %s\n", sendAmount, destinationAddress)
 
 	validateConfirm := func(userResponse string) error {
 		userResponse = strings.TrimSpace(userResponse)
 		userResponse = strings.Trim(userResponse, `"`)
-		if userResponse == "" || strings.EqualFold("Y", userResponse) || strings.EqualFold("n", userResponse) {
+		if strings.EqualFold("Y", userResponse) || strings.EqualFold("n", userResponse) {
 			return nil
 		} else {
 			return fmt.Errorf("invalid option, try again")
 		}
 	}
-	confirm, err := terminalprompt.RequestInput("Are you sure? (y/N) ", validateConfirm)
+	confirm, err := terminalprompt.RequestInput("Are you sure? (y/n) ", validateConfirm)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading your response: %s", err.Error())
 		return err

--- a/cli/commands/send.go
+++ b/cli/commands/send.go
@@ -87,14 +87,14 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 			return fmt.Errorf("invalid option, try again")
 		}
 	}
-	confirm, err := terminalprompt.RequestInput("Are you sure? (y/n) ", validateConfirm)
+	confirm, err := terminalprompt.RequestInput("Are you sure? (y/n)", validateConfirm)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading your response: %s", err.Error())
 		return err
 	}
 
 	if strings.EqualFold(confirm, "n") {
-		fmt.Println("Operation cancelled")
+		fmt.Println("Canceled")
 		return nil
 	}
 

--- a/cli/commands/send.go
+++ b/cli/commands/send.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/raedahgroup/godcr/cli/termio/terminalprompt"
 	"github.com/raedahgroup/godcr/app/walletcore"
 	"github.com/raedahgroup/godcr/cli/runner"
+	"github.com/raedahgroup/godcr/cli/termio/terminalprompt"
 )
 
 // SendCommand lets the user send DCR.
@@ -77,11 +77,15 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 
 	fmt.Printf("You are about to send %f DCR to %s\n", sendAmount, destinationAddress)
 
-	confirm, _ := terminalprompt.RequestInput("Are you sure? (y/n) ", nil)
+	confirm, _ := terminalprompt.RequestInput("Are you sure? (y/N) ", nil)
 
 	if strings.EqualFold(confirm, "yes") || strings.EqualFold(confirm, "y") {
+		confirm = "y"
+	}
+
+	if confirm != "y" {
 		fmt.Printf("Operation cancelled\n")
-		return  nil
+		return nil
 	}
 
 	var sentTransactionHash string
@@ -96,6 +100,6 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 		return err
 	}
 
-	fmt.Printf("Sent. Txid: %s\n", sentTransactionHash)
+	fmt.Println("Sent. Txid", sentTransactionHash)
 	return nil
 }

--- a/cli/commands/send.go
+++ b/cli/commands/send.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/raedahgroup/godcr/walletrpcclient"
 	"github.com/raedahgroup/godcr/cli/termio/terminalprompt"
+	"github.com/raedahgroup/godcr/app/walletcore"
+	"github.com/raedahgroup/godcr/cli/runner"
 )
 
 // SendCommand lets the user send DCR.
@@ -83,7 +84,8 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 		return  nil
 	}
 
-	var result *walletrpcclient.SendResult
+	var sentTransactionHash string
+
 	if custom {
 		sentTransactionHash, err = wallet.SendFromUTXOs(utxoSelection, sendAmount, sourceAccount, destinationAddress, passphrase)
 	} else {
@@ -94,6 +96,6 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 		return err
 	}
 
-	fmt.Println("sent. txid %s", result.TransactionHash)
+	fmt.Printf("Sent. Txid: %s\n", sentTransactionHash)
 	return nil
 }

--- a/cli/commands/send.go
+++ b/cli/commands/send.go
@@ -76,7 +76,7 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 		return err
 	}
 
-	fmt.Printf("You are about to send %f DCR to %s\n", sendAmount, destinationAddress)
+	fmt.Println("You are about to send %f DCR to %s", sendAmount, destinationAddress)
 
 	validateConfirm := func(userResponse string) error {
 		userResponse = strings.TrimSpace(userResponse)
@@ -93,12 +93,8 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 		return err
 	}
 
-	if strings.EqualFold(confirm, "yes") || strings.EqualFold(confirm, "y") {
-		confirm = "y"
-	}
-
-	if confirm != "y" {
-		fmt.Printf("Operation cancelled\n")
+	if strings.EqualFold(confirm, "n") {
+		fmt.Println("Operation cancelled")
 		return nil
 	}
 

--- a/cli/commands/send.go
+++ b/cli/commands/send.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/raedahgroup/godcr/app/walletcore"
@@ -77,7 +78,20 @@ func send(wallet walletcore.Wallet, custom bool) (err error) {
 
 	fmt.Printf("You are about to send %f DCR to %s\n", sendAmount, destinationAddress)
 
-	confirm, _ := terminalprompt.RequestInput("Are you sure? (y/N) ", nil)
+	validateConfirm := func(userResponse string) error {
+		userResponse = strings.TrimSpace(userResponse)
+		userResponse = strings.Trim(userResponse, `"`)
+		if userResponse == "" || strings.EqualFold("Y", userResponse) || strings.EqualFold("n", userResponse) {
+			return nil
+		} else {
+			return fmt.Errorf("invalid option, try again")
+		}
+	}
+	confirm, err := terminalprompt.RequestInput("Are you sure? (y/N) ", validateConfirm)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading your response: %s", err.Error())
+		return err
+	}
 
 	if strings.EqualFold(confirm, "yes") || strings.EqualFold(confirm, "y") {
 		confirm = "y"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/decred/dcrwallet/walletseed v1.0.0
 	github.com/go-chi/chi v3.3.3+incompatible
 	github.com/jessevdk/go-flags v1.4.0
+	github.com/mdp/qrterminal v1.0.1
 	github.com/raedahgroup/mobilewallet v1.0.0-rc1.0.20181228083835-ea62e1bb09f1
 	github.com/skip2/go-qrcode v0.0.0-20171229120447-cf5f9fa2f0d8
 	golang.org/x/image v0.0.0-20181116024801-cd38e8056d9b

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.2/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mdp/qrterminal v1.0.1 h1:07+fzVDlPuBlXS8tB0ktTAyf+Lp1j2+2zK3fBOL5b7c=
+github.com/mdp/qrterminal v1.0.1/go.mod h1:Z33WhxQe9B6CdW37HaVqcRKzP+kByF3q/qLxOGe12xQ=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.1 h1:PZSj/UFNaVp3KxrzHOcS7oyuWA7LoOY/77yCTEFu21U=
@@ -284,3 +286,5 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
+rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func enterHttpMode(ctx context.Context, walletMiddleware app.WalletMiddleware, a
 }
 
 // todo need to add shutdown functionality to this mode
-func enterDesktopMode (ctx context.Context, walletMiddleware app.WalletMiddleware) {
+func enterDesktopMode(ctx context.Context, walletMiddleware app.WalletMiddleware) {
 	fmt.Println("Launching desktop app")
 	desktop.StartDesktopApp(ctx, walletMiddleware)
 	// desktop app closed, trigger shutdown


### PR DESCRIPTION
Regarding the smaller QR size unless you want to display PNG in the command line via importing another PNG rendering library the size cannot be changeable pretty much any way as if you select a pixel on the output you will see it as being one unit of black or white. API does not support resizing this type of textual character output. (practically it only supports PNG and Image size change which is not what we are outputting) (Ref https://godoc.org/github.com/skip2/go-qrcode)

Fixes #54