### PR TITLE
use default dcrwallet rpc address if none is specified in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ var (
 type Config struct {
 	ShowVersion       bool   `short:"v" long:"version" description:"Display version information and exit"`
 	ConfigFile        string `short:"C" long:"configfile" description:"Path to configuration file"`
+	TestNet           bool   `short:"t" long:"testnet" description:"Connects to testnet wallet instead of mainnet"`
 	RPCUser           string `short:"u" long:"rpcuser" description:"RPC username"`
 	RPCPassword       string `short:"p" long:"rpcpass" default-mask:"-" description:"RPC password"`
 	WalletRPCServer   string `short:"w" long:"walletrpcserver" description:"Wallet RPC server to connect to"`
@@ -57,9 +58,9 @@ func AppName() string {
 // LoadConfig parses program configuration from both the CLI flags and the config file.
 func LoadConfig() (*Config, *flags.Parser, error) {
 	// load defaults first
-	commands := defaultConfig()
+	config := defaultConfig()
 
-	parser := flags.NewParser(&commands, flags.HelpFlag)
+	parser := flags.NewParser(&config, flags.HelpFlag)
 
 	// stub out the command handler so that the commands are not run at while loading configuration.
 	parser.CommandHandler = func(command flags.Commander, args []string) error {
@@ -71,12 +72,12 @@ func LoadConfig() (*Config, *flags.Parser, error) {
 		return nil, parser, err
 	}
 
-	if commands.ShowVersion {
+	if config.ShowVersion {
 		return nil, parser, fmt.Errorf(AppVersion())
 	}
 
 	// Load additional config from file
-	err = flags.NewIniParser(parser).ParseFile(commands.ConfigFile)
+	err = flags.NewIniParser(parser).ParseFile(config.ConfigFile)
 	if err != nil {
 		if _, ok := err.(*os.PathError); !ok {
 			return nil, parser, fmt.Errorf("Error parsing configuration file: %v", err.Error())
@@ -90,5 +91,5 @@ func LoadConfig() (*Config, *flags.Parser, error) {
 		return nil, parser, err
 	}
 
-	return &commands, parser, nil
+	return &config, parser, nil
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	client, err := walletrpcclient.New(appConfig.WalletRPCServer, appConfig.RPCCert, appConfig.NoDaemonTLS)
+	client, err := walletrpcclient.New(appConfig.WalletRPCServer, appConfig.RPCCert, appConfig.NoDaemonTLS, appConfig.TestNet)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error connecting to RPC server")
 		fmt.Fprintln(os.Stderr, err.Error())


### PR DESCRIPTION
Dcrwallet rpc address is required to successfully run dcrcli. The address can be specified in 
- `dcrcli.conf` using `walletrpcserver=address:port`
- or in command-line options using `--walletrpcserver="address:port"` or `-w="address:port"`

Currently, if the address is not supplied using any of the methods above, the following connection error occurs:
`rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = "transport: Error while dialing dial tcp: missing address"`

This PR prevents that error by using `localhost:9111` and `localhost:19111` as default address value for mainnet and testnet respectively. These are the default addresses dcrwallet rpc listens on if the user does not manually specify a different address in dcrwallet.conf.
To achieve the above, this PR introduces a new dcrcli flag (--testnet, -t) to distinguish between running in testnet and mainnet.

There is yet another possible connection error not solved by this PR. Regardless of how dcrwallet server address is supplied (either via `.conf` file, command-line options or default value), if the dcrwallet daemon is not running at that address, a different kind of connection error is thrown. Another issue (#77) has been created to track the fix for this second possible connection error.

To illustrate this other possible connection error
- do not set rpc listen address for dcrwallet (allow the program to use the default value)
- do not set dcrwallet rpc address for dcrcli (allow the program to use the default value)
- start dcrwallet in testnet mode
- attempt to run a dcrcli command using testnet (e.g. `dcrcli -t balance`)
- run the same command again but without the testnet flag
- the second run attempt should produce a connection error