### PR TITLE
Command categories

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 }
 
 // defaultConfig an instance of Config with the defaults set.
-func defaultConfig() Config {
+func DefaultConfig() Config {
 	return Config{
 		AppDataDir:        defaultAppDataDir,
 		ConfigFile:        defaultConfigFile,
@@ -54,7 +54,7 @@ func defaultConfig() Config {
 // However, unknown options in the configuration file must return an error.
 func LoadConfig(ignoreUnknownOptions bool) ([]string, Config, *flags.Parser, error) {
 	// load defaults first
-	config := defaultConfig()
+	config := DefaultConfig()
 
 	parser := flags.NewParser(&config, flags.HelpFlag)
 	if ignoreUnknownOptions {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -50,7 +50,7 @@ func Run(ctx context.Context, walletMiddleware app.WalletMiddleware, appConfig c
 	}
 
 	if noCommandPassed {
-		displayAvailableCommandsHelpMessage(parser)
+		listCommands()
 	} else if helpFlagPassed {
 		displayHelpMessage(parser.Name, parser.Active)
 	} else if err != nil {
@@ -69,15 +69,12 @@ func syncBlockChain(ctx context.Context, walletMiddleware app.WalletMiddleware) 
 	return walletloader.SyncBlockChain(ctx, walletMiddleware)
 }
 
-// displayAvailableCommandsHelpMessage prints a simple list of available commands when godcr is run without any command
-func displayAvailableCommandsHelpMessage(parser *flags.Parser) {
-	registeredCommands := parser.Commands()
-	commandNames := make([]string, 0, len(registeredCommands))
-	for _, command := range registeredCommands {
-		commandNames = append(commandNames, command.Name)
+// listCommands prints a simple list of available commands when godcr is run without any command
+func listCommands() {
+	for _, category := range commands.Categories() {
+		sort.Strings(category.CommandNames)
+		fmt.Fprintf(os.Stderr, "%s: %s\n", category.ShortName, strings.Join(category.CommandNames, ", "))
 	}
-	sort.Strings(commandNames)
-	fmt.Fprintln(os.Stderr, "Available Commands: ", strings.Join(commandNames, ", "))
 }
 
 func displayHelpMessage(appName string, activeCommand *flags.Command) {

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -19,7 +19,7 @@ type AvailableCommands struct {
 
 // AvailableCommands defines experimental commands and options available on the cli
 type ExperimentalCommands struct {
-	SendCustom      SendCustomCommand      `command:"send-custom" description:"Send a transaction, manually selecting inputs from unspent outputs"`
+	SendCustom SendCustomCommand `command:"send-custom" description:"Send a transaction, manually selecting inputs from unspent outputs"`
 }
 
 // Categories return information for the different categories of commands defined in this file
@@ -35,8 +35,8 @@ func Categories() []*help.CommandCategory {
 	}
 
 	return []*help.CommandCategory{
-		{ Name: "Available Commands", ShortName: "available cmds", CommandNames: parseCommandNames(&AvailableCommands{}) },
-		{ Name: "Experimental Commands", ShortName: "experimental", CommandNames: parseCommandNames(&ExperimentalCommands{}) },
+		{Name: "Available Commands", ShortName: "available cmds", CommandNames: parseCommandNames(&AvailableCommands{})},
+		{Name: "Experimental Commands", ShortName: "experimental", CommandNames: parseCommandNames(&ExperimentalCommands{})},
 	}
 }
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -1,15 +1,43 @@
 package commands
 
-// Commands defines the commands and options available on the cli
-type Commands struct {
+import (
+	"reflect"
+
+	"github.com/raedahgroup/godcr/cli/help"
+)
+
+// AvailableCommands defines thoroughly-tested commands and options available on the cli
+type AvailableCommands struct {
 	CreateWallet    CreateWalletCommand    `command:"create-wallet" description:"Creates a new decred testnet or mainnet wallet" long-description:"Creates a new decred testnet or mainnet wallet. A wallet seed will be generated for the new wallet which must be stored securely. You'll also be asked to set a password for the wallet"`
 	Balance         BalanceCommand         `command:"balance" description:"Show total balance for each account in wallet" long-description:"Also shows spendable balance if different from total balance"`
 	Send            SendCommand            `command:"send" description:"Send a transaction"`
-	SendCustom      SendCustomCommand      `command:"send-custom" description:"Send a transaction, manually selecting inputs from unspent outputs"`
 	Receive         ReceiveCommand         `command:"receive" description:"Show your address to receive funds"`
 	History         HistoryCommand         `command:"history" description:"Show your transaction history"`
 	ShowTransaction ShowTransactionCommand `command:"show-transaction" description:"Show details of a transaction"`
 	Help            HelpCommand            `command:"help" description:"Show general application help. Run help <command-name> to get help message for a specific command"`
+}
+
+// AvailableCommands defines experimental commands and options available on the cli
+type ExperimentalCommands struct {
+	SendCustom      SendCustomCommand      `command:"send-custom" description:"Send a transaction, manually selecting inputs from unspent outputs"`
+}
+
+// Categories return information for the different categories of commands defined in this file
+func Categories() []*help.CommandCategory {
+	parseCommandNames := func(commandCategory interface{}) (commandNames []string) {
+		commandData := reflect.ValueOf(commandCategory).Elem()
+		dataType := commandData.Type()
+
+		for i := 0; i < commandData.NumField(); i++ {
+			commandNames = append(commandNames, dataType.Field(i).Tag.Get("command"))
+		}
+		return
+	}
+
+	return []*help.CommandCategory{
+		{ Name: "Available Commands", CommandNames: parseCommandNames(&AvailableCommands{}) },
+		{ Name: "Experimental Commands", CommandNames: parseCommandNames(&ExperimentalCommands{}) },
+	}
 }
 
 // commanderStub implements `flags.Commander`, using a noop Execute method to satisfy `flags.Commander` interface

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -35,8 +35,8 @@ func Categories() []*help.CommandCategory {
 	}
 
 	return []*help.CommandCategory{
-		{ Name: "Available Commands", CommandNames: parseCommandNames(&AvailableCommands{}) },
-		{ Name: "Experimental Commands", CommandNames: parseCommandNames(&ExperimentalCommands{}) },
+		{ Name: "Available Commands", ShortName: "available cmds", CommandNames: parseCommandNames(&AvailableCommands{}) },
+		{ Name: "Experimental Commands", ShortName: "experimental", CommandNames: parseCommandNames(&ExperimentalCommands{}) },
 	}
 }
 

--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"fmt"
 	"github.com/jessevdk/go-flags"
+	"github.com/raedahgroup/godcr/cli/help"
 	"github.com/raedahgroup/godcr/cli/termio"
+	"os"
 )
 
 type HelpCommand struct {
@@ -27,57 +29,7 @@ func (h HelpCommand) Run(parser *flags.Parser) error {
 		return fmt.Errorf("unknown command %q", h.Args.CommandName)
 	}
 
-	PrintCommandHelp(parser.Name, targetCommand)
+	help.PrintCommandHelp(os.Stdout, parser.Name, targetCommand)
 
 	return nil
-}
-
-func PrintCommandHelp(appName string, command *flags.Command) {
-	tabWriter := termio.StdoutWriter
-	fmt.Fprintln(tabWriter, fmt.Sprintf("%s. %s\n", command.ShortDescription, command.LongDescription))
-
-	usageText := fmt.Sprintf("Usage:\n  %s %s", appName, command.Name)
-	args := command.Args()
-	if args != nil && len(args) > 0 {
-		usageText += " [args]"
-	}
-	usageText += " [options]"
-	fmt.Fprintln(tabWriter, usageText)
-	fmt.Fprintln(tabWriter)
-
-	if args != nil && len(args) > 0 {
-		fmt.Fprintln(tabWriter, "Arguments:")
-		for _, arg := range args {
-			required := ""
-			if arg.Required == 1 {
-				required = "(required)"
-			}
-			fmt.Fprintln(tabWriter, fmt.Sprintf("  %s %s \t %s", arg.Name, required, arg.Description))
-		}
-		fmt.Fprintln(tabWriter)
-	}
-
-	options := command.Options()
-	if options != nil && len(options) > 0 {
-		fmt.Fprintln(tabWriter, "Options:")
-		// option printout attempts to add 2 whitespace for options with short name and 6 for those without
-		// This is an attempt to stay consistent with the output of parser.WriteHelp
-		for _, option := range options {
-			var optionUsage string
-
-			if option.ShortName != 0 && option.LongName != "" {
-				optionUsage = fmt.Sprintf("  -%c, --%s", option.ShortName, option.LongName)
-			} else if option.ShortName != 0 {
-				optionUsage = fmt.Sprintf("  -%c", option.ShortName)
-			} else {
-				optionUsage = fmt.Sprintf("      --%s", option.LongName)
-			}
-
-			fmt.Fprintln(tabWriter, fmt.Sprintf("%s \t %s", optionUsage, option.Description))
-		}
-		fmt.Fprintln(tabWriter)
-	}
-
-	fmt.Fprintln(tabWriter, fmt.Sprintf("Use %s -h to view application options", appName))
-	tabWriter.Flush()
 }

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -1,0 +1,134 @@
+package help
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/raedahgroup/godcr/cli/termio"
+)
+
+type CommandCategory struct {
+	Name string
+	CommandNames []string
+}
+
+func commandCategoryName(commandName string, commandCategories []*CommandCategory) string {
+	for _, category := range commandCategories {
+		for _, command := range category.CommandNames {
+			if commandName == command {
+				return category.Name
+			}
+		}
+	}
+	return "Other commands"
+}
+
+func PrintGeneralHelp(output io.Writer, parser *flags.Parser, commandCategories []*CommandCategory) {
+	tabWriter := termio.TabWriter(output)
+
+	// print usage
+	fmt.Fprintf(tabWriter, "Usage:\n  %s [options] <command> [args]\n", parser.Name)
+	fmt.Fprintln(tabWriter)
+
+	// print general app options
+	for _, optionGroup := range parser.Groups() {
+		printOptions(tabWriter, optionGroup.ShortDescription, optionGroup.Options())
+	}
+
+	// loop through all commands registered on parser and separate into groups
+	commandGroups := map[string][]*flags.Command{}
+	for _, command := range parser.Commands() {
+		commandCategory := commandCategoryName(command.Name, commandCategories)
+		commandGroups[commandCategory] = append(commandGroups[commandCategory], command)
+	}
+	printCommands(tabWriter, commandGroups)
+}
+
+func PrintCommandHelp(output io.Writer, appName string, command *flags.Command) {
+	tabWriter := termio.TabWriter(output)
+
+	// command description
+	fmt.Fprintln(tabWriter, fmt.Sprintf("%s. %s\n", command.ShortDescription, command.LongDescription))
+
+	usageText := fmt.Sprintf("Usage:\n  %s %s", appName, command.Name)
+	args := command.Args()
+	if args != nil && len(args) > 0 {
+		usageText += " [args]"
+	}
+	usageText += " [options]"
+	fmt.Fprintln(tabWriter, usageText)
+	fmt.Fprintln(tabWriter)
+
+	if args != nil && len(args) > 0 {
+		fmt.Fprintln(tabWriter, "Arguments:")
+		for _, arg := range args {
+			required := ""
+			if arg.Required == 1 {
+				required = "(required)"
+			}
+			fmt.Fprintln(tabWriter, fmt.Sprintf("  %s %s \t %s", arg.Name, required, arg.Description))
+		}
+		fmt.Fprintln(tabWriter)
+	}
+
+	printOptions(tabWriter, "Command options:", command.Options())
+
+	fmt.Fprintln(tabWriter, fmt.Sprintf("Use `%s -h` to view application options", appName))
+	tabWriter.Flush()
+}
+
+// option printout attempts to add 2 whitespace for options with short name and 6 for those without
+// This is an attempt to stay consistent with the output of parser.WriteHelp
+func printOptions(tabWriter io.Writer, optionDescription string, options []*flags.Option) {
+	if options != nil && len(options) > 0 {
+		fmt.Fprintln(tabWriter, optionDescription)
+
+		for _, option := range options {
+			var optionUsage string
+
+			if option.ShortName != 0 && option.LongName != "" {
+				optionUsage = fmt.Sprintf("  -%c, --%s", option.ShortName, option.LongName)
+			} else if option.ShortName != 0 {
+				optionUsage = fmt.Sprintf("  -%c", option.ShortName)
+			} else {
+				optionUsage = fmt.Sprintf("      --%s", option.LongName)
+			}
+
+			if option.Field().Type.Kind() != reflect.Bool {
+				optionUsage += "="
+			}
+
+			description := option.Description
+			optionDefaultValue := reflect.ValueOf(option.Value())
+			if optionDefaultValue.Kind() == reflect.String {
+				description += fmt.Sprintf(" (default: %s)", optionDefaultValue.String())
+			}
+
+			fmt.Fprintln(tabWriter, fmt.Sprintf("%s \t %s", optionUsage, description))
+		}
+
+		fmt.Fprintln(tabWriter)
+	}
+}
+
+func printCommands(tabWriter io.Writer, commandGroups map[string][]*flags.Command) {
+	// sort first to ensure consistent display order
+	categories := make([]string, 0, len(commandGroups))
+	for category := range commandGroups {
+		categories = append(categories, category)
+	}
+	sort.Strings(categories)
+
+	for _, category := range categories {
+		fmt.Fprintf(tabWriter, "%s:\n", category)
+
+		for _, command := range commandGroups[category] {
+			fmt.Fprintln(tabWriter, fmt.Sprintf("  %s \t %s", command.Name, command.ShortDescription))
+		}
+
+		fmt.Fprintln(tabWriter)
+	}
+}

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -12,6 +12,7 @@ import (
 
 type CommandCategory struct {
 	Name string
+	ShortName string
 	CommandNames []string
 }
 

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -11,8 +11,8 @@ import (
 )
 
 type CommandCategory struct {
-	Name string
-	ShortName string
+	Name         string
+	ShortName    string
 	CommandNames []string
 }
 


### PR DESCRIPTION
This PR fixes #105 by introducing command categories and using custom code to print help information in order to reflect the different categories of commands.

As seen from the following screenshots, the new help message output is very identical to what was obtainable using `parser.WriteHelp()`

**New output (with categories)**
![screenshot 2019-01-02 at 2 31 25 am](https://user-images.githubusercontent.com/18400051/50578207-c7864880-0e36-11e9-9dd9-13820e7dcfd7.png)

**Previous output (`parser.WriteHelp()`)**
![screenshot 2019-01-02 at 1 18 49 am](https://user-images.githubusercontent.com/18400051/50578213-e97fcb00-0e36-11e9-9628-48e7a7c2bf83.png)

Also, this PR restores the expected output of running godcr without a command as specified in #53:
![screenshot 2019-01-02 at 2 31 57 am](https://user-images.githubusercontent.com/18400051/50578227-07e5c680-0e37-11e9-89d2-5703cd30fb20.png)
