### PR TITLE
cleanup config options/flags, simplify help command output

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -19,7 +19,7 @@ var (
 	defaultDcrwalletAppDataDir = dcrutil.AppDataDir("dcrwallet", false)
 	defaultRPCCertFile         = filepath.Join(defaultDcrwalletAppDataDir, "rpc.cert")
 
-	configFilePath          = filepath.Join(defaultAppDataDir, defaultConfigFilename)
+	configFilePath = filepath.Join(defaultAppDataDir, defaultConfigFilename)
 )
 
 // Config holds the top-level options/flags for the application
@@ -41,12 +41,12 @@ type ConfFileOptions struct {
 
 // CommandLineOptions holds the top-level options/flags that are displayed on the command-line menu
 type CommandLineOptions struct {
-	InterfaceMode     string   `long:"mode" description:"Interface mode to run" choice:"cli" choice:"http" choice:"nuklear"`
+	InterfaceMode string `long:"mode" description:"Interface mode to run" choice:"cli" choice:"http" choice:"nuklear"`
 	CliOptions
 }
 
 type CliOptions struct {
-	SyncBlockchain    bool	 `long:"sync" description:"Syncs blockchain when running in cli mode. If used with a command, command is executed after blockchain syncs"`
+	SyncBlockchain bool `long:"sync" description:"Syncs blockchain when running in cli mode. If used with a command, command is executed after blockchain syncs"`
 }
 
 func defaultFileOptions() ConfFileOptions {

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -34,8 +34,8 @@ type Config struct {
 
 // CommandLineOptions holds the top-level options/flags that are displayed on the command-line menu
 type CommandLineOptions struct {
-	ConfigFile        string `short:"C" long:"configfile" description:"Path to configuration file"`
 	ShowVersion       bool   `short:"v" long:"version" description:"Display version information and exit. Any other flag or command is ignored."`
+	ConfigFile        string `short:"c" long:"configfile" description:"Path to configuration file"`
 	UseTestNet        bool   `short:"t" long:"testnet" description:"Connects to testnet wallet instead of mainnet"`
 	UseWalletRPC      bool   `short:"w" long:"usewalletrpc" description:"Connect to a running drcwallet daemon over rpc to perform wallet operations"`
 	HTTPMode          bool   `long:"http" description:"Run in HTTP mode"`

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 }
 
 // defaultConfig an instance of Config with the defaults set.
-func defaultConfig() Config {
+func DefaultConfig() Config {
 	return Config{
 		AppDataDir:        defaultAppDataDir,
 		ConfigFile:        defaultConfigFile,
@@ -54,7 +54,7 @@ func defaultConfig() Config {
 // However, unknown options in the configuration file must return an error.
 func LoadConfig(ignoreUnknownOptions bool) ([]string, Config, *flags.Parser, error) {
 	// load defaults first
-	config := defaultConfig()
+	config := DefaultConfig()
 
 	parser := flags.NewParser(&config, flags.HelpFlag)
 	if ignoreUnknownOptions {

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -57,11 +57,6 @@ func defaultFileOptions() ConfFileOptions {
 	}
 }
 
-// DefaultCommandLineOptions returns a CommandLineOptions object populated with default values
-func DefaultCommandLineOptions() CommandLineOptions {
-	return CommandLineOptions{}
-}
-
 // defaultConfig an instance of Config with the defaults set.
 func defaultConfig() Config {
 	return Config{

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -41,7 +41,7 @@ type ConfFileOptions struct {
 
 // CommandLineOptions holds the top-level options/flags that are displayed on the command-line menu
 type CommandLineOptions struct {
-	InterfaceMode     string   `short:"m" long:"mode" description:"Interface mode to run" choice:"cli" choice:"http" choice:"nuklear"`
+	InterfaceMode     string   `long:"mode" description:"Interface mode to run" choice:"cli" choice:"http" choice:"nuklear"`
 	CliOptions
 }
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -25,11 +25,7 @@ var (
 // Config holds the top-level options/flags for the application
 type Config struct {
 	CommandLineOptions
-	AppDataDir        string `short:"A" long:"appdata" description:"Path to application data directory"`
-	WalletRPCServer   string `long:"walletrpcserver" description:"Wallet RPC server address to connect to"`
-	WalletRPCCert     string `long:"walletrpccert" description:"Path to dcrwallet certificate file"`
-	NoWalletRPCTLS    bool   `long:"nowalletrpctls" description:"Disable TLS when connecting to dcrwallet daemon via RPC"`
-	HTTPServerAddress string `long:"httpserveraddress" description:"Address and port for the HTTP server"`
+	ConfFileOptions
 }
 
 // CommandLineOptions holds the top-level options/flags that are displayed on the command-line menu
@@ -42,9 +38,26 @@ type CommandLineOptions struct {
 	DesktopMode       bool   `long:"desktop" description:"Run in Desktop mode"`
 }
 
+// CommandLineOptions holds the top-level options/flags that are best set in config file rather than in command-line
+type ConfFileOptions struct {
+	AppDataDir        string `short:"A" long:"appdata" description:"Path to application data directory"`
+	WalletRPCServer   string `long:"walletrpcserver" description:"Wallet RPC server address to connect to"`
+	WalletRPCCert     string `long:"walletrpccert" description:"Path to dcrwallet certificate file"`
+	NoWalletRPCTLS    bool   `long:"nowalletrpctls" description:"Disable TLS when connecting to dcrwallet daemon via RPC"`
+	HTTPServerAddress string `long:"httpserveraddress" description:"Address and port for the HTTP server"`
+}
+
 func DefaultCommandLineOptions() CommandLineOptions {
 	return CommandLineOptions{
 		ConfigFile:        defaultConfigFile,
+	}
+}
+
+func defaultFileOptions() ConfFileOptions {
+	return ConfFileOptions{
+		AppDataDir:        defaultAppDataDir,
+		WalletRPCCert:     defaultRPCCertFile,
+		HTTPServerAddress: defaultHTTPServerAddress,
 	}
 }
 
@@ -52,9 +65,7 @@ func DefaultCommandLineOptions() CommandLineOptions {
 func defaultConfig() Config {
 	return Config{
 		CommandLineOptions: DefaultCommandLineOptions(),
-		AppDataDir:        defaultAppDataDir,
-		WalletRPCCert:     defaultRPCCertFile,
-		HTTPServerAddress: defaultHTTPServerAddress,
+		ConfFileOptions: defaultFileOptions(),
 	}
 }
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -22,26 +22,37 @@ var (
 	defaultConfigFile          = filepath.Join(defaultAppDataDir, defaultConfigFilename)
 )
 
-// Config holds the top-level options for the application and cli-only command options/flags/args
+// Config holds the top-level options/flags for the application
 type Config struct {
+	CommandLineOptions
 	AppDataDir        string `short:"A" long:"appdata" description:"Path to application data directory"`
+	WalletRPCServer   string `long:"walletrpcserver" description:"Wallet RPC server address to connect to"`
+	WalletRPCCert     string `long:"walletrpccert" description:"Path to dcrwallet certificate file"`
+	NoWalletRPCTLS    bool   `long:"nowalletrpctls" description:"Disable TLS when connecting to dcrwallet daemon via RPC"`
+	HTTPServerAddress string `long:"httpserveraddress" description:"Address and port for the HTTP server"`
+}
+
+// CommandLineOptions holds the top-level options/flags that are displayed on the command-line menu
+type CommandLineOptions struct {
 	ConfigFile        string `short:"C" long:"configfile" description:"Path to configuration file"`
 	ShowVersion       bool   `short:"v" long:"version" description:"Display version information and exit. Any other flag or command is ignored."`
 	UseTestNet        bool   `short:"t" long:"testnet" description:"Connects to testnet wallet instead of mainnet"`
 	UseWalletRPC      bool   `short:"w" long:"usewalletrpc" description:"Connect to a running drcwallet daemon over rpc to perform wallet operations"`
-	WalletRPCServer   string `long:"walletrpcserver" description:"Wallet RPC server address to connect to"`
-	WalletRPCCert     string `long:"walletrpccert" description:"Path to dcrwallet certificate file"`
-	NoWalletRPCTLS    bool   `long:"nowalletrpctls" description:"Disable TLS when connecting to dcrwallet daemon via RPC"`
 	HTTPMode          bool   `long:"http" description:"Run in HTTP mode"`
-	HTTPServerAddress string `long:"httpserveraddress" description:"Address and port for the HTTP server"`
 	DesktopMode       bool   `long:"desktop" description:"Run in Desktop mode"`
+}
+
+func DefaultCommandLineOptions() CommandLineOptions {
+	return CommandLineOptions{
+		ConfigFile:        defaultConfigFile,
+	}
 }
 
 // defaultConfig an instance of Config with the defaults set.
 func defaultConfig() Config {
 	return Config{
+		CommandLineOptions: DefaultCommandLineOptions(),
 		AppDataDir:        defaultAppDataDir,
-		ConfigFile:        defaultConfigFile,
 		WalletRPCCert:     defaultRPCCertFile,
 		HTTPServerAddress: defaultHTTPServerAddress,
 	}

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -32,8 +32,6 @@ type Config struct {
 type CommandLineOptions struct {
 	ShowVersion       bool   `short:"v" long:"version" description:"Display version information and exit. Any other flag or command is ignored."`
 	ConfigFile        string `short:"c" long:"configfile" description:"Path to configuration file"`
-	UseTestNet        bool   `short:"t" long:"testnet" description:"Connects to testnet wallet instead of mainnet"`
-	UseWalletRPC      bool   `short:"w" long:"usewalletrpc" description:"Connect to a running drcwallet daemon over rpc to perform wallet operations"`
 	HTTPMode          bool   `long:"http" description:"Run in HTTP mode"`
 	DesktopMode       bool   `long:"desktop" description:"Run in Desktop mode"`
 }
@@ -41,6 +39,8 @@ type CommandLineOptions struct {
 // CommandLineOptions holds the top-level options/flags that are best set in config file rather than in command-line
 type ConfFileOptions struct {
 	AppDataDir        string `short:"A" long:"appdata" description:"Path to application data directory"`
+	UseTestNet        bool   `short:"t" long:"testnet" description:"Connects to testnet wallet instead of mainnet"`
+	UseWalletRPC      bool   `short:"w" long:"usewalletrpc" description:"Connect to a running drcwallet daemon over rpc to perform wallet operations"`
 	WalletRPCServer   string `long:"walletrpcserver" description:"Wallet RPC server address to connect to"`
 	WalletRPCCert     string `long:"walletrpccert" description:"Path to dcrwallet certificate file"`
 	NoWalletRPCTLS    bool   `long:"nowalletrpctls" description:"Disable TLS when connecting to dcrwallet daemon via RPC"`

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	defaultConfigFilename    = "godcr.conf"
-	defaultHTTPServerAddress = "127.0.0.1:1234"
+	defaultHTTPServerAddress = "127.0.0.1:7778"
 )
 
 var (

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -20,7 +20,6 @@ import (
 type appConfigWithCliCommands struct {
 	commands.Commands
 	config.Config
-	runner.CliOptions
 }
 
 // Run starts the app in cli interface mode

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -69,6 +69,7 @@ func syncBlockChain(ctx context.Context, walletMiddleware app.WalletMiddleware) 
 
 // listCommands prints a simple list of available commands when godcr is run without any command
 func listCommands() {
+	help.PrintOptionsSimple(os.Stdout, commands.HelpParser().Groups())
 	for _, category := range commands.Categories() {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", category.ShortName, strings.Join(category.CommandNames, ", "))
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -50,7 +50,7 @@ func Run(ctx context.Context, walletMiddleware app.WalletMiddleware, appConfig c
 	}
 
 	if noCommandPassed {
-		displayAvailableCommandsHelpMessage(parser)
+		listCommands()
 	} else if helpFlagPassed {
 		displayHelpMessage(parser.Name, parser.Active)
 	} else if err != nil {
@@ -69,15 +69,12 @@ func syncBlockChain(ctx context.Context, walletMiddleware app.WalletMiddleware) 
 	return walletloader.SyncBlockChain(ctx, walletMiddleware)
 }
 
-// displayAvailableCommandsHelpMessage prints a simple list of available commands when godcr is run without any command
-func displayAvailableCommandsHelpMessage(parser *flags.Parser) {
-	registeredCommands := parser.Commands()
-	commandNames := make([]string, 0, len(registeredCommands))
-	for _, command := range registeredCommands {
-		commandNames = append(commandNames, command.Name)
+// listCommands prints a simple list of available commands when godcr is run without any command
+func listCommands() {
+	for _, category := range commands.Categories() {
+		sort.Strings(category.CommandNames)
+		fmt.Fprintf(os.Stderr, "%s: %s\n", category.ShortName, strings.Join(category.CommandNames, ", "))
 	}
-	sort.Strings(commandNames)
-	fmt.Fprintln(os.Stderr, "Available Commands: ", strings.Join(commandNames, ", "))
 }
 
 func displayHelpMessage(appName string, activeCommand *flags.Command) {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/jessevdk/go-flags"
@@ -71,7 +70,6 @@ func syncBlockChain(ctx context.Context, walletMiddleware app.WalletMiddleware) 
 // listCommands prints a simple list of available commands when godcr is run without any command
 func listCommands() {
 	for _, category := range commands.Categories() {
-		sort.Strings(category.CommandNames)
 		fmt.Fprintf(os.Stderr, "%s: %s\n", category.ShortName, strings.Join(category.CommandNames, ", "))
 	}
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -49,8 +49,10 @@ func Run(ctx context.Context, walletMiddleware app.WalletMiddleware, appConfig c
 
 	if noCommandPassed {
 		displayAvailableCommandsHelpMessage(parser)
+	} else if helpFlagPassed && parser.Active == nil {
+		displayGeneralHelpMessage()
 	} else if helpFlagPassed {
-		displayHelpMessage(parser)
+		commands.PrintCommandHelp(parser.Name, parser.Active)
 	} else if err != nil {
 		fmt.Println(err)
 	}
@@ -78,10 +80,16 @@ func displayAvailableCommandsHelpMessage(parser *flags.Parser) {
 	fmt.Fprintln(os.Stderr, "Available Commands: ", strings.Join(commandNames, ", "))
 }
 
-func displayHelpMessage(parser *flags.Parser) {
-	if parser.Active == nil {
-		parser.WriteHelp(os.Stdout)
-	} else {
-		commands.PrintCommandHelp(parser.Name, parser.Active)
+// displayGeneralHelpMessage creates a help parser with command line options and cli commands to display general help message
+func displayGeneralHelpMessage() {
+	commandLineConfigWithCliCommands := struct{
+		config.CommandLineOptions
+		commands.Commands
+		runner.CliOptions
+	}{
+		CommandLineOptions: config.DefaultCommandLineOptions(),
 	}
+
+	helpParser := flags.NewParser(&commandLineConfigWithCliCommands, flags.HelpFlag|flags.PassDoubleDash)
+	helpParser.WriteHelp(os.Stdout)
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -50,9 +50,9 @@ func Run(ctx context.Context, walletMiddleware app.WalletMiddleware, appConfig c
 	if noCommandPassed {
 		displayAvailableCommandsHelpMessage(parser)
 	} else if helpFlagPassed && parser.Active == nil {
-		displayGeneralHelpMessage()
+		commands.DisplayGeneralHelpMessage()
 	} else if helpFlagPassed {
-		commands.PrintCommandHelp(parser.Name, parser.Active)
+		commands.DisplayCommandHelp(parser.Name, parser.Active)
 	} else if err != nil {
 		fmt.Println(err)
 	}
@@ -78,18 +78,4 @@ func displayAvailableCommandsHelpMessage(parser *flags.Parser) {
 	}
 	sort.Strings(commandNames)
 	fmt.Fprintln(os.Stderr, "Available Commands: ", strings.Join(commandNames, ", "))
-}
-
-// displayGeneralHelpMessage creates a help parser with command line options and cli commands to display general help message
-func displayGeneralHelpMessage() {
-	commandLineConfigWithCliCommands := struct{
-		config.CommandLineOptions
-		commands.Commands
-		runner.CliOptions
-	}{
-		CommandLineOptions: config.DefaultCommandLineOptions(),
-	}
-
-	helpParser := flags.NewParser(&commandLineConfigWithCliCommands, flags.HelpFlag|flags.PassDoubleDash)
-	helpParser.WriteHelp(os.Stdout)
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -35,7 +35,7 @@ func Categories() []*help.CommandCategory {
 	}
 
 	return []*help.CommandCategory{
-		{Name: "Available Commands", ShortName: "available cmds", CommandNames: parseCommandNames(&AvailableCommands{})},
+		{Name: "Available Commands", ShortName: "commands", CommandNames: parseCommandNames(&AvailableCommands{})},
 		{Name: "Experimental Commands", ShortName: "experimental", CommandNames: parseCommandNames(&ExperimentalCommands{})},
 	}
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -19,7 +19,7 @@ type AvailableCommands struct {
 
 // AvailableCommands defines experimental commands and options available on the cli
 type ExperimentalCommands struct {
-	SendCustom      SendCustomCommand      `command:"send-custom" description:"Send a transaction, manually selecting inputs from unspent outputs"`
+	SendCustom SendCustomCommand `command:"send-custom" description:"Send a transaction, manually selecting inputs from unspent outputs"`
 }
 
 // Categories return information for the different categories of commands defined in this file
@@ -35,8 +35,8 @@ func Categories() []*help.CommandCategory {
 	}
 
 	return []*help.CommandCategory{
-		{ Name: "Available Commands", ShortName: "available cmds", CommandNames: parseCommandNames(&AvailableCommands{}) },
-		{ Name: "Experimental Commands", ShortName: "experimental", CommandNames: parseCommandNames(&ExperimentalCommands{}) },
+		{Name: "Available Commands", ShortName: "available cmds", CommandNames: parseCommandNames(&AvailableCommands{})},
+		{Name: "Experimental Commands", ShortName: "experimental", CommandNames: parseCommandNames(&ExperimentalCommands{})},
 	}
 }
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -35,8 +35,8 @@ func Categories() []*help.CommandCategory {
 	}
 
 	return []*help.CommandCategory{
-		{Name: "Available Commands", ShortName: "commands", CommandNames: parseCommandNames(&AvailableCommands{})},
-		{Name: "Experimental Commands", ShortName: "experimental", CommandNames: parseCommandNames(&ExperimentalCommands{})},
+		{Name: "Available Commands", ShortName: "Commands", CommandNames: parseCommandNames(&AvailableCommands{})},
+		{Name: "Experimental Commands", ShortName: "Experimental", CommandNames: parseCommandNames(&ExperimentalCommands{})},
 	}
 }
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -1,15 +1,43 @@
 package commands
 
-// Commands defines the commands and options available on the cli
-type Commands struct {
+import (
+	"reflect"
+
+	"github.com/raedahgroup/godcr/cli/help"
+)
+
+// AvailableCommands defines thoroughly-tested commands and options available on the cli
+type AvailableCommands struct {
 	CreateWallet    CreateWalletCommand    `command:"create-wallet" description:"Creates a new decred testnet or mainnet wallet" long-description:"Creates a new decred testnet or mainnet wallet. A wallet seed will be generated for the new wallet which must be stored securely. You'll also be asked to set a password for the wallet"`
 	Balance         BalanceCommand         `command:"balance" description:"Show total balance for each account in wallet" long-description:"Also shows spendable balance if different from total balance"`
 	Send            SendCommand            `command:"send" description:"Send a transaction"`
-	SendCustom      SendCustomCommand      `command:"send-custom" description:"Send a transaction, manually selecting inputs from unspent outputs"`
 	Receive         ReceiveCommand         `command:"receive" description:"Show your address to receive funds"`
 	History         HistoryCommand         `command:"history" description:"Show your transaction history"`
 	ShowTransaction ShowTransactionCommand `command:"show-transaction" description:"Show details of a transaction"`
 	Help            HelpCommand            `command:"help" description:"Show general application help. Run help <command-name> to get help message for a specific command"`
+}
+
+// AvailableCommands defines experimental commands and options available on the cli
+type ExperimentalCommands struct {
+	SendCustom      SendCustomCommand      `command:"send-custom" description:"Send a transaction, manually selecting inputs from unspent outputs"`
+}
+
+// Categories return information for the different categories of commands defined in this file
+func Categories() []*help.CommandCategory {
+	parseCommandNames := func(commandCategory interface{}) (commandNames []string) {
+		commandData := reflect.ValueOf(commandCategory).Elem()
+		dataType := commandData.Type()
+
+		for i := 0; i < commandData.NumField(); i++ {
+			commandNames = append(commandNames, dataType.Field(i).Tag.Get("command"))
+		}
+		return
+	}
+
+	return []*help.CommandCategory{
+		{ Name: "Available Commands", CommandNames: parseCommandNames(&AvailableCommands{}) },
+		{ Name: "Experimental Commands", CommandNames: parseCommandNames(&ExperimentalCommands{}) },
+	}
 }
 
 // commanderStub implements `flags.Commander`, using a noop Execute method to satisfy `flags.Commander` interface

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -35,8 +35,8 @@ func Categories() []*help.CommandCategory {
 	}
 
 	return []*help.CommandCategory{
-		{ Name: "Available Commands", CommandNames: parseCommandNames(&AvailableCommands{}) },
-		{ Name: "Experimental Commands", CommandNames: parseCommandNames(&ExperimentalCommands{}) },
+		{ Name: "Available Commands", ShortName: "available cmds", CommandNames: parseCommandNames(&AvailableCommands{}) },
+		{ Name: "Experimental Commands", ShortName: "experimental", CommandNames: parseCommandNames(&ExperimentalCommands{}) },
 	}
 }
 

--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"fmt"
 	"github.com/jessevdk/go-flags"
+	"github.com/raedahgroup/godcr/cli/help"
 	"github.com/raedahgroup/godcr/cli/termio"
+	"os"
 )
 
 type HelpCommand struct {
@@ -27,57 +29,7 @@ func (h HelpCommand) Run(parser *flags.Parser) error {
 		return fmt.Errorf("unknown command %q", h.Args.CommandName)
 	}
 
-	PrintCommandHelp(parser.Name, targetCommand)
+	help.PrintCommandHelp(os.Stdout, parser.Name, targetCommand)
 
 	return nil
-}
-
-func PrintCommandHelp(appName string, command *flags.Command) {
-	tabWriter := termio.StdoutWriter
-	fmt.Fprintln(tabWriter, fmt.Sprintf("%s. %s\n", command.ShortDescription, command.LongDescription))
-
-	usageText := fmt.Sprintf("Usage:\n  %s %s", appName, command.Name)
-	args := command.Args()
-	if args != nil && len(args) > 0 {
-		usageText += " [args]"
-	}
-	usageText += " [options]"
-	fmt.Fprintln(tabWriter, usageText)
-	fmt.Fprintln(tabWriter)
-
-	if args != nil && len(args) > 0 {
-		fmt.Fprintln(tabWriter, "Arguments:")
-		for _, arg := range args {
-			required := ""
-			if arg.Required == 1 {
-				required = "(required)"
-			}
-			fmt.Fprintln(tabWriter, fmt.Sprintf("  %s %s \t %s", arg.Name, required, arg.Description))
-		}
-		fmt.Fprintln(tabWriter)
-	}
-
-	options := command.Options()
-	if options != nil && len(options) > 0 {
-		fmt.Fprintln(tabWriter, "Options:")
-		// option printout attempts to add 2 whitespace for options with short name and 6 for those without
-		// This is an attempt to stay consistent with the output of parser.WriteHelp
-		for _, option := range options {
-			var optionUsage string
-
-			if option.ShortName != 0 && option.LongName != "" {
-				optionUsage = fmt.Sprintf("  -%c, --%s", option.ShortName, option.LongName)
-			} else if option.ShortName != 0 {
-				optionUsage = fmt.Sprintf("  -%c", option.ShortName)
-			} else {
-				optionUsage = fmt.Sprintf("      --%s", option.LongName)
-			}
-
-			fmt.Fprintln(tabWriter, fmt.Sprintf("%s \t %s", optionUsage, option.Description))
-		}
-		fmt.Fprintln(tabWriter)
-	}
-
-	fmt.Fprintln(tabWriter, fmt.Sprintf("Use %s -h to view application options", appName))
-	tabWriter.Flush()
 }

--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"fmt"
+	"github.com/raedahgroup/godcr/app"
+	"os"
+
 	"github.com/jessevdk/go-flags"
 	"github.com/raedahgroup/godcr/app/config"
-	"github.com/raedahgroup/godcr/cli/runner"
 	"github.com/raedahgroup/godcr/cli/termio"
-	"os"
 )
 
 type HelpCommand struct {
@@ -35,14 +36,14 @@ func (h HelpCommand) Run(parser *flags.Parser) error {
 type GeneralHelpData struct {
 	config.CommandLineOptions
 	Commands
-	runner.CliOptions `group:"CLI Interface Options"`
 }
 
 // DisplayGeneralHelpMessage creates a help parser with command line options and cli commands to display general help message
 func DisplayGeneralHelpMessage() {
-	helpData := GeneralHelpData{
-		CommandLineOptions: config.DefaultCommandLineOptions(),
-	}
+	// print version text first
+	fmt.Printf("%s version: %s\n", app.Name(), app.Version())
+
+	helpData := GeneralHelpData{}
 
 	helpParser := flags.NewParser(&helpData, flags.HelpFlag|flags.PassDoubleDash)
 	helpParser.WriteHelp(os.Stdout)

--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -33,7 +33,7 @@ func (h HelpCommand) Run(parser *flags.Parser) error {
 }
 
 type GeneralHelpData struct {
-	config.CommandLineOptions `group:"Options"`
+	config.CommandLineOptions `group:"Options" description:"description" long-description:"long-description"`
 	AvailableCommands
 	ExperimentalCommands
 }

--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -33,7 +33,7 @@ func (h HelpCommand) Run(parser *flags.Parser) error {
 }
 
 type GeneralHelpData struct {
-	config.CommandLineOptions `group:"Options" description:"description" long-description:"long-description"`
+	config.CommandLineOptions `group:"Options:"`
 	AvailableCommands
 	ExperimentalCommands
 }

--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -32,18 +32,19 @@ func (h HelpCommand) Run(parser *flags.Parser) error {
 	return nil
 }
 
+type GeneralHelpData struct {
+	config.CommandLineOptions
+	Commands
+	runner.CliOptions `group:"CLI Interface Options"`
+}
 
 // DisplayGeneralHelpMessage creates a help parser with command line options and cli commands to display general help message
 func DisplayGeneralHelpMessage() {
-	commandLineConfigWithCliCommands := struct{
-		config.CommandLineOptions
-		Commands
-		runner.CliOptions
-	}{
+	helpData := GeneralHelpData{
 		CommandLineOptions: config.DefaultCommandLineOptions(),
 	}
 
-	helpParser := flags.NewParser(&commandLineConfigWithCliCommands, flags.HelpFlag|flags.PassDoubleDash)
+	helpParser := flags.NewParser(&helpData, flags.HelpFlag|flags.PassDoubleDash)
 	helpParser.WriteHelp(os.Stdout)
 }
 

--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -34,14 +34,14 @@ func (h HelpCommand) Run(parser *flags.Parser) error {
 }
 
 type GeneralHelpData struct {
-	config.CommandLineOptions
+	config.CommandLineOptions `group:"Options"`
 	Commands
 }
 
 // DisplayGeneralHelpMessage creates a help parser with command line options and cli commands to display general help message
 func DisplayGeneralHelpMessage() {
 	// print version text first
-	fmt.Printf("%s version: %s\n", app.Name(), app.Version())
+	fmt.Printf("%s v%s\n", app.Name(), app.Version())
 
 	helpData := GeneralHelpData{}
 

--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -33,7 +33,7 @@ func (h HelpCommand) Run(parser *flags.Parser) error {
 }
 
 type GeneralHelpData struct {
-	config.CommandLineOptions
+	config.CommandLineOptions `group:"Options"`
 	AvailableCommands
 	ExperimentalCommands
 }

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -1,0 +1,134 @@
+package help
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/raedahgroup/godcr/cli/termio"
+)
+
+type CommandCategory struct {
+	Name string
+	CommandNames []string
+}
+
+func commandCategoryName(commandName string, commandCategories []*CommandCategory) string {
+	for _, category := range commandCategories {
+		for _, command := range category.CommandNames {
+			if commandName == command {
+				return category.Name
+			}
+		}
+	}
+	return "Other commands"
+}
+
+func PrintGeneralHelp(output io.Writer, parser *flags.Parser, commandCategories []*CommandCategory) {
+	tabWriter := termio.TabWriter(output)
+
+	// print usage
+	fmt.Fprintf(tabWriter, "Usage:\n  %s [options] <command> [args]\n", parser.Name)
+	fmt.Fprintln(tabWriter)
+
+	// print general app options
+	for _, optionGroup := range parser.Groups() {
+		printOptions(tabWriter, optionGroup.ShortDescription, optionGroup.Options())
+	}
+
+	// loop through all commands registered on parser and separate into groups
+	commandGroups := map[string][]*flags.Command{}
+	for _, command := range parser.Commands() {
+		commandCategory := commandCategoryName(command.Name, commandCategories)
+		commandGroups[commandCategory] = append(commandGroups[commandCategory], command)
+	}
+	printCommands(tabWriter, commandGroups)
+}
+
+func PrintCommandHelp(output io.Writer, appName string, command *flags.Command) {
+	tabWriter := termio.TabWriter(output)
+
+	// command description
+	fmt.Fprintln(tabWriter, fmt.Sprintf("%s. %s\n", command.ShortDescription, command.LongDescription))
+
+	usageText := fmt.Sprintf("Usage:\n  %s %s", appName, command.Name)
+	args := command.Args()
+	if args != nil && len(args) > 0 {
+		usageText += " [args]"
+	}
+	usageText += " [options]"
+	fmt.Fprintln(tabWriter, usageText)
+	fmt.Fprintln(tabWriter)
+
+	if args != nil && len(args) > 0 {
+		fmt.Fprintln(tabWriter, "Arguments:")
+		for _, arg := range args {
+			required := ""
+			if arg.Required == 1 {
+				required = "(required)"
+			}
+			fmt.Fprintln(tabWriter, fmt.Sprintf("  %s %s \t %s", arg.Name, required, arg.Description))
+		}
+		fmt.Fprintln(tabWriter)
+	}
+
+	printOptions(tabWriter, "Command options:", command.Options())
+
+	fmt.Fprintln(tabWriter, fmt.Sprintf("Use `%s -h` to view application options", appName))
+	tabWriter.Flush()
+}
+
+// option printout attempts to add 2 whitespace for options with short name and 6 for those without
+// This is an attempt to stay consistent with the output of parser.WriteHelp
+func printOptions(tabWriter io.Writer, optionDescription string, options []*flags.Option) {
+	if options != nil && len(options) > 0 {
+		fmt.Fprintln(tabWriter, optionDescription)
+
+		for _, option := range options {
+			var optionUsage string
+
+			if option.ShortName != 0 && option.LongName != "" {
+				optionUsage = fmt.Sprintf("  -%c, --%s", option.ShortName, option.LongName)
+			} else if option.ShortName != 0 {
+				optionUsage = fmt.Sprintf("  -%c", option.ShortName)
+			} else {
+				optionUsage = fmt.Sprintf("      --%s", option.LongName)
+			}
+
+			if option.Field().Type.Kind() != reflect.Bool {
+				optionUsage += "="
+			}
+
+			description := option.Description
+			optionDefaultValue := reflect.ValueOf(option.Value())
+			if optionDefaultValue.Kind() == reflect.String {
+				description += fmt.Sprintf(" (default: %s)", optionDefaultValue.String())
+			}
+
+			fmt.Fprintln(tabWriter, fmt.Sprintf("%s \t %s", optionUsage, description))
+		}
+
+		fmt.Fprintln(tabWriter)
+	}
+}
+
+func printCommands(tabWriter io.Writer, commandGroups map[string][]*flags.Command) {
+	// sort first to ensure consistent display order
+	categories := make([]string, 0, len(commandGroups))
+	for category := range commandGroups {
+		categories = append(categories, category)
+	}
+	sort.Strings(categories)
+
+	for _, category := range categories {
+		fmt.Fprintf(tabWriter, "%s:\n", category)
+
+		for _, command := range commandGroups[category] {
+			fmt.Fprintln(tabWriter, fmt.Sprintf("  %s \t %s", command.Name, command.ShortDescription))
+		}
+
+		fmt.Fprintln(tabWriter)
+	}
+}

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -36,6 +36,9 @@ func PrintGeneralHelp(output io.Writer, parser *flags.Parser, commandCategories 
 	fmt.Fprintf(tabWriter, "%s v%s\n", app.Name(), app.Version())
 	fmt.Fprintln(tabWriter)
 
+	// print general app options
+	printOptionGroups(tabWriter, parser.Groups())
+
 	// loop through all commands registered on parser and separate into groups
 	commandGroups := map[string][]*flags.Command{}
 	for _, command := range parser.Commands() {
@@ -43,9 +46,6 @@ func PrintGeneralHelp(output io.Writer, parser *flags.Parser, commandCategories 
 		commandGroups[commandCategory] = append(commandGroups[commandCategory], command)
 	}
 	printCommands(tabWriter, commandGroups)
-
-	// print general app options
-	printOptionGroups(tabWriter, parser.Groups())
 }
 
 func printOptionGroups(output io.Writer, groups []*flags.Group) {
@@ -160,7 +160,8 @@ func printCommands(tabWriter io.Writer, commandGroups map[string][]*flags.Comman
 	for _, category := range categories {
 		fmt.Fprintf(tabWriter, "%s:\n", category)
 
-		for _, command := range commandGroups[category] {
+		commands := commandGroups[category]
+		for _, command := range commands {
 			fmt.Fprintln(tabWriter, fmt.Sprintf("  %s \t %s", command.Name, command.ShortDescription))
 		}
 

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -12,6 +12,7 @@ import (
 
 type CommandCategory struct {
 	Name string
+	ShortName string
 	CommandNames []string
 }
 

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -45,8 +45,16 @@ func PrintGeneralHelp(output io.Writer, parser *flags.Parser, commandCategories 
 	printCommands(tabWriter, commandGroups)
 
 	// print general app options
-	for _, optionGroup := range parser.Groups() {
-		printOptions(tabWriter, optionGroup.ShortDescription, optionGroup.Options())
+	printOptionGroups(tabWriter, parser.Groups())
+}
+
+func printOptionGroups(output io.Writer, groups []*flags.Group) {
+	for _, optionGroup := range groups {
+		if len(optionGroup.Groups()) > 0 {
+			printOptionGroups(output, optionGroup.Groups())
+		} else {
+			printOptions(output, optionGroup.ShortDescription, optionGroup.Options())
+		}
 	}
 }
 

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -32,7 +32,7 @@ func PrintGeneralHelp(output io.Writer, parser *flags.Parser, commandCategories 
 	tabWriter := termio.TabWriter(output)
 
 	// print version
-	fmt.Fprintf(tabWriter,"%s v%s\n", app.Name(), app.Version())
+	fmt.Fprintf(tabWriter, "%s v%s\n", app.Name(), app.Version())
 	fmt.Fprintln(tabWriter)
 
 	// loop through all commands registered on parser and separate into groups

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -11,8 +11,8 @@ import (
 )
 
 type CommandCategory struct {
-	Name string
-	ShortName string
+	Name         string
+	ShortName    string
 	CommandNames []string
 }
 

--- a/cli/help/utils.go
+++ b/cli/help/utils.go
@@ -1,0 +1,100 @@
+package help
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+)
+
+// printOptionGroups checks if the root parser option group has nested option groups and prints all
+func printOptionGroups(output io.Writer, groups []*flags.Group) {
+	for _, optionGroup := range groups {
+		if len(optionGroup.Groups()) > 0 {
+			printOptionGroups(output, optionGroup.Groups())
+		} else {
+			printOptions(output, optionGroup.ShortDescription, optionGroup.Options())
+		}
+	}
+}
+
+// printOptions adds 2 trailing whitespace for options with short name and 6 for those without
+// This is an attempt to stay consistent with the output of parser.WriteHelp
+func printOptions(tabWriter io.Writer, optionDescription string, options []*flags.Option) {
+	if options != nil && len(options) > 0 {
+		fmt.Fprintln(tabWriter, optionDescription)
+
+		// check if there's any option in this group with short and long name
+		// this will help to decide whether or not to pad options without short name to maintain readability
+		var hasOptionsWithShortName bool
+		for _, option := range options {
+			if option.ShortName != 0 && option.LongName != "" {
+				hasOptionsWithShortName = true
+				break
+			}
+		}
+
+		for _, option := range options {
+			optionUsage := parseOptionUsageText(option, hasOptionsWithShortName)
+			description := parseOptionDescription(option)
+			fmt.Fprintln(tabWriter, fmt.Sprintf("  %s \t %s", optionUsage, description))
+		}
+
+		fmt.Fprintln(tabWriter)
+	}
+}
+
+func parseOptionUsageText(option *flags.Option, hasOptionsWithShortName bool) (optionUsage string) {
+	if option.ShortName != 0 && option.LongName != "" {
+		optionUsage = fmt.Sprintf("-%c, --%s", option.ShortName, option.LongName)
+	} else if option.ShortName != 0 {
+		optionUsage = fmt.Sprintf("-%c", option.ShortName)
+	} else if hasOptionsWithShortName {
+		// pad long name with 4 spaces to align with options having short and long names
+		optionUsage = fmt.Sprintf("    --%s", option.LongName)
+	} else {
+		optionUsage = fmt.Sprintf("--%s", option.LongName)
+	}
+
+	if option.Field().Type.Kind() != reflect.Bool {
+		optionUsage += "="
+	}
+
+	if len(option.Choices) > 0 {
+		optionUsage += fmt.Sprintf("[%s]", strings.Join(option.Choices, ","))
+	}
+
+	return
+}
+
+func parseOptionDescription(option *flags.Option) (description string) {
+	description = option.Description
+	optionDefaultValue := reflect.ValueOf(option.Value())
+	if optionDefaultValue.Kind() == reflect.String && optionDefaultValue.String() != "" {
+		description += fmt.Sprintf(" (default: %s)", optionDefaultValue.String())
+	}
+	return
+}
+
+func printCommands(tabWriter io.Writer, commandGroups map[string][]*flags.Command) {
+	// sort first to ensure consistent display order
+	categories := make([]string, 0, len(commandGroups))
+	for category := range commandGroups {
+		categories = append(categories, category)
+	}
+	sort.Strings(categories)
+
+	for _, category := range categories {
+		fmt.Fprintf(tabWriter, "%s:\n", category)
+
+		commands := commandGroups[category]
+		for _, command := range commands {
+			fmt.Fprintln(tabWriter, fmt.Sprintf("  %s \t %s", command.Name, command.ShortDescription))
+		}
+
+		fmt.Fprintln(tabWriter)
+	}
+}

--- a/cli/runner/options.go
+++ b/cli/runner/options.go
@@ -1,6 +1,0 @@
-package runner
-
-// CliOptions defines options available only when running in cli interface mode
-type CliOptions struct {
-	SyncBlockchain bool `long:"sync" description:"Syncs blockchain when running in cli mode. If used with a command, command is executed after blockchain syncs"`
-}

--- a/cli/runner/runner.go
+++ b/cli/runner/runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/jessevdk/go-flags"
 	"github.com/raedahgroup/godcr/app"
+	"github.com/raedahgroup/godcr/app/config"
 	"github.com/raedahgroup/godcr/cli/walletloader"
 )
 
@@ -23,7 +24,7 @@ func New(ctx context.Context, walletMiddleware app.WalletMiddleware) *CommandRun
 // Run checks if a command implements `IWalletRunner` and executes the command using the command's Run method
 // Other commands are executed using the Execute method implemented by those commands
 // If the command does not implement either Run or Execute method, a broken command error is returned
-func (runner CommandRunner) Run(parser *flags.Parser, command flags.Commander, args []string, options CliOptions) error {
+func (runner CommandRunner) Run(parser *flags.Parser, command flags.Commander, args []string, options config.CliOptions) error {
 	if command == nil {
 		return brokenCommandError(parser.Command)
 	}
@@ -50,7 +51,7 @@ func (runner CommandRunner) Run(parser *flags.Parser, command flags.Commander, a
 // Such commands must implement `WalletCommandRunner` by providing a Run function
 // The wallet is opened using the provided walletMiddleware, sync operations performed (if requested)
 // then, the command is executed using the Run method of the WalletCommandRunner interface
-func (runner CommandRunner) processWalletCommand(commandRunner WalletCommandRunner, args []string, options CliOptions) error {
+func (runner CommandRunner) processWalletCommand(commandRunner WalletCommandRunner, args []string, options config.CliOptions) error {
 	walletExists, err := walletloader.OpenWallet(runner.ctx, runner.walletMiddleware)
 	if err != nil || !walletExists {
 		return err

--- a/main.go
+++ b/main.go
@@ -49,9 +49,9 @@ func main() {
 	walletMiddleware := connectToWallet(ctx, appConfig)
 	shutdownOps = append(shutdownOps, walletMiddleware.CloseWallet)
 
-	if appConfig.HTTPMode {
+	if appConfig.InterfaceMode == "http" {
 		enterHttpMode(ctx, walletMiddleware, args, appConfig)
-	} else if appConfig.DesktopMode {
+	} else if appConfig.InterfaceMode == "nuklear" {
 		enterDesktopMode(ctx, walletMiddleware)
 	} else {
 		enterCliMode(ctx, walletMiddleware, appConfig)


### PR DESCRIPTION
Fixes #105 and #106 

Output of `godcr -h` and `godcr help` now shows fewer app options/flags which can be passed in command-line. Other options/flags that are best configured in `godcr.conf` are no longer displayed on the command-line menu. All valid application options remain valid, whether passed in command-line or saved in `godcr.conf`. The goal of this PR is to keep the command-line less cluttered when showing general help message.

This PR also combines work from #108, introducing command categories and using custom code to print help information in order to reflect the different categories of commands.

As seen from the following screenshots, the new help message output is very identical to what was obtainable using `parser.WriteHelp()`

**New output (with categories)**
![screenshot 2019-01-02 at 5 06 47 am](https://user-images.githubusercontent.com/18400051/50580244-6bc6ba00-0e4c-11e9-9c84-c9f42ebbea07.png)

**Previous output (`parser.WriteHelp()`)**
![screenshot 2019-01-02 at 1 18 49 am](https://user-images.githubusercontent.com/18400051/50578213-e97fcb00-0e36-11e9-9628-48e7a7c2bf83.png)

Also, this PR restores the expected output of running godcr without a command as specified in #53:
![screenshot 2019-01-02 at 6 34 25 am](https://user-images.githubusercontent.com/18400051/50581308-dbdb3d00-0e58-11e9-9509-b5c111231c47.png)
