### PR TITLE
show qrcode on terminal without inverting colors

### DIFF
--- a/cli/commands/receive.go
+++ b/cli/commands/receive.go
@@ -48,7 +48,7 @@ func (receiveCommand ReceiveCommand) Run(wallet walletcore.Wallet) error {
 	fmt.Println(receiveAddress)
 
 	// Print out QR code?
-	printQR, err := terminalprompt.RequestYesNoConfirmation("Would you like to generate a QR code?", "N")
+	printQR, err := terminalprompt.RequestYesNoConfirmation("View QR code?", "N")
 	if err != nil {
 		return fmt.Errorf("error reading your response: %s", err.Error())
 	}
@@ -58,7 +58,7 @@ func (receiveCommand ReceiveCommand) Run(wallet walletcore.Wallet) error {
 		if err != nil {
 			return fmt.Errorf("error generating QR code, %s", err.Error())
 		}
-		fmt.Fprintf(os.Stdout, qr.ToSmallString(true))
+		fmt.Fprintf(os.Stdout, qr.ToSmallString(false))
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #129 
`godcr receive` output:

![screenshot 2019-01-06 at 12 39 56 am](https://user-images.githubusercontent.com/18400051/50730362-dc6f1e80-114b-11e9-80f2-cf0efc29e93d.png)
