### PR TITLE
separate ReceiveAddress from GenerateAddress

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -99,9 +99,9 @@ func LoadConfig(ignoreUnknownOptions bool) ([]string, Config, *flags.Parser, err
 			optionName = arg[1:]
 		}
 		if isFileOption := isConfigFileOption(optionName); isFileOption {
-			return args, config, parser, fmt.Errorf("Unexpected command-line flag/option, " +
-				"see godcr -h for supported command-line flags/options" +
-				"\nSet other flags/options in %s", AppConfigFilePath)
+			return args, config, parser, fmt.Errorf("Unexpected command-line flag/option, "+
+				"see godcr -h for supported command-line flags/options"+
+				"\nSet other flags/options in %s", configFilePath)
 		}
 	}
 
@@ -136,7 +136,7 @@ func parseConfigFile(parser *flags.Parser) error {
 	return nil
 }
 
-func isConfigFileOption(name string) ( isFileOption bool) {
+func isConfigFileOption(name string) (isFileOption bool) {
 	if name == "" {
 		return
 	}

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -101,7 +101,7 @@ func LoadConfig(ignoreUnknownOptions bool) ([]string, Config, *flags.Parser, err
 		if isFileOption := isConfigFileOption(optionName); isFileOption {
 			return args, config, parser, fmt.Errorf("Unexpected command-line flag/option, "+
 				"see godcr -h for supported command-line flags/options"+
-				"\nSet other flags/options in %s", configFilePath)
+				"\nSet other flags/options in %s", AppConfigFilePath)
 		}
 	}
 

--- a/app/walletcore/wallet.go
+++ b/app/walletcore/wallet.go
@@ -32,8 +32,13 @@ type Wallet interface {
 	// ValidateAddress checks if an address is valid or not
 	ValidateAddress(address string) (bool, error)
 
-	// GenerateReceiveAddress generates an address to receive funds into specified account
-	GenerateReceiveAddress(account uint32) (string, error)
+	// ReceiveAddress checks if there's a previously generated address that hasn't been used to receive funds and returns it
+	// If no unused address exists, it generates a new address to receive funds into specified account
+	ReceiveAddress(account uint32) (string, error)
+
+	// GenerateNewAddress generates a new address to receive funds into specified account
+	// regardless of whether there was a previously generated address that has not been used
+	GenerateNewAddress(account uint32) (string, error)
 
 	// UnspentOutputs lists all unspent outputs in the specified account that sum up to `targetAmount`
 	// If `targetAmount` is 0, all unspent outputs in account are returned

--- a/app/walletmediums/dcrlibwallet/walletfunctions.go
+++ b/app/walletmediums/dcrlibwallet/walletfunctions.go
@@ -81,8 +81,12 @@ func (lib *DcrWalletLib) ValidateAddress(address string) (bool, error) {
 	return lib.walletLib.IsAddressValid(address), nil
 }
 
-func (lib *DcrWalletLib) GenerateReceiveAddress(account uint32) (string, error) {
+func (lib *DcrWalletLib) ReceiveAddress(account uint32) (string, error) {
 	return lib.walletLib.CurrentAddress(int32(account))
+}
+
+func (lib *DcrWalletLib) GenerateNewAddress(account uint32) (string, error) {
+	return lib.walletLib.NextAddress(int32(account))
 }
 
 func (lib *DcrWalletLib) UnspentOutputs(account uint32, targetAmount int64, requiredConfirmations int32) ([]*walletcore.UnspentOutput, error) {

--- a/app/walletmediums/dcrwalletrpc/walletfunctions.go
+++ b/app/walletmediums/dcrwalletrpc/walletfunctions.go
@@ -137,7 +137,27 @@ func (c *WalletPRCClient) ValidateAddress(address string) (bool, error) {
 	return err == nil, nil
 }
 
-func (c *WalletPRCClient) GenerateReceiveAddress(account uint32) (string, error) {
+// ReceiveAddress uses GAP_POLICY_WRAP which returns previously generated unused addresses ONLY if the gap limit is exceeded
+// Ideally, ReceiveAddress should always return the last generated address that has not been used
+func (c *WalletPRCClient) ReceiveAddress(account uint32) (string, error) {
+	req := &walletrpc.NextAddressRequest{
+		Account:   account,
+		GapPolicy: walletrpc.NextAddressRequest_GAP_POLICY_WRAP,
+		Kind:      walletrpc.NextAddressRequest_BIP0044_EXTERNAL,
+	}
+
+	nextAddress, err := c.walletService.NextAddress(context.Background(), req)
+	if err != nil {
+		return "", err
+	}
+
+	return nextAddress.Address, nil
+}
+
+// GenerateNewAddress uses GAP_POLICY_WRAP which returns previously generated unused addresses ONLY if the gap limit is exceeded
+// Ideally, GenerateNewAddress should always generate new addresses but we have to be wary of issues that could arise if the gap limit is exceeded
+// GenerateNewAddress will continue to generate new addresses until/unless the gap limit is met, then it'll revert to previously generated addresses
+func (c *WalletPRCClient) GenerateNewAddress(account uint32) (string, error) {
 	req := &walletrpc.NextAddressRequest{
 		Account:   account,
 		GapPolicy: walletrpc.NextAddressRequest_GAP_POLICY_WRAP,

--- a/cli/commands/helpers.go
+++ b/cli/commands/helpers.go
@@ -187,7 +187,7 @@ func getChangeDestinationsWithRandomAmounts(wallet walletcore.Wallet, amountInAt
 
 	var changeAddresses []string
 	for i := 0; i < nChangeOutputs; i++ {
-		address, err := wallet.GenerateReceiveAddress(sourceAccount)
+		address, err := wallet.GenerateNewAddress(sourceAccount)
 		if err != nil {
 			return nil, fmt.Errorf("error generating address: %s", err.Error())
 		}
@@ -231,7 +231,7 @@ func getChangeDestinationsFromUser(wallet walletcore.Wallet, amountInAtom int64,
 
 	var index int
 	for {
-		address, err := wallet.GenerateReceiveAddress(sourceAccount)
+		address, err := wallet.GenerateNewAddress(sourceAccount)
 		if err != nil {
 			return nil, fmt.Errorf("error in generating address: %s", err.Error())
 		}

--- a/cli/commands/receive.go
+++ b/cli/commands/receive.go
@@ -39,7 +39,7 @@ func (receiveCommand ReceiveCommand) Run(wallet walletcore.Wallet) error {
 		}
 	}
 
-	receiveAddress, err := wallet.GenerateReceiveAddress(accountNumber)
+	receiveAddress, err := wallet.ReceiveAddress(accountNumber)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/send.go
+++ b/cli/commands/send.go
@@ -129,7 +129,6 @@ func completeCustomSend(wallet walletcore.Wallet, sourceAccount uint32, sendDest
 	}
 
 	if !sendConfirmed {
-		fmt.Println("Canceled")
 		return "", errors.New("transaction canceled")
 	}
 

--- a/desktop/handlers.go
+++ b/desktop/handlers.go
@@ -188,7 +188,7 @@ func (d *Desktop) ReceiveHandler(w *nucular.Window) {
 
 					// get address
 					if generateAddressResponse == "" && err == nil {
-						generateAddressResponse, err = d.wallet.GenerateReceiveAddress(selectedAccountNumber)
+						generateAddressResponse, err = d.wallet.ReceiveAddress(selectedAccountNumber)
 						if err != nil {
 							content.setErrorMessage(err.Error())
 						} else {

--- a/web/routes/handlers.go
+++ b/web/routes/handlers.go
@@ -109,7 +109,7 @@ func (routes *Routes) submitSendTxForm(res http.ResponseWriter, req *http.Reques
 			return
 		}
 
-		changeAddress, err := routes.walletMiddleware.GenerateReceiveAddress(sourceAccount)
+		changeAddress, err := routes.walletMiddleware.GenerateNewAddress(sourceAccount)
 		if err != nil {
 			data["error"] = err.Error()
 			return
@@ -164,7 +164,7 @@ func (routes *Routes) generateReceiveAddress(res http.ResponseWriter, req *http.
 		return
 	}
 
-	address, err := routes.walletMiddleware.GenerateReceiveAddress(uint32(accountNumber))
+	address, err := routes.walletMiddleware.ReceiveAddress(uint32(accountNumber))
 	if err != nil {
 		data["success"] = false
 		data["message"] = err.Error()


### PR DESCRIPTION
Currently, there is one core wallet function for generating address in a wallet's account: `GenerateReceiveAddress`. This function is implemented differently for `dcrlibwallet` and `dcrwalletrpc`.

While `dcrwalletrpc` almost always generates a new address every time the function is called, `dcrlibwallet` only generates a new address if the previous address has been used to receive funds. This would cause problems with the new feature being implemented in #123 to support multiple change outputs, where each change output requires generation of a unique address even though the previously generated address is yet to be used to receive funds.

Still, when a user requests an address to use for funds receipt, by default, godcr should not generate a new address unless the previously generated address has been used. However, if the user really wants a new address generated, we can make provision for that in the different interfaces. A new issue will cover that scenario.

For now, this PR comes with the following changes:
- 2 new core wallet functions: `ReceiveAddress` and `GenerateNewAddress`
- Receive feature uses `ReceiveAddress` which may not always generate a new address. Ideally, it would return previously generated and unused address
- Send feature uses `GenerateNewAddress` when dealing with change outputs to prevent address re-use because no 2 change outputs for a single transaction should use the same address