### PR TITLE
refactor core functions to accept required confs parameter

### DIFF
--- a/app/walletcore/wallet.go
+++ b/app/walletcore/wallet.go
@@ -2,15 +2,19 @@ package walletcore
 
 import "github.com/raedahgroup/dcrlibwallet/txhelper"
 
+// standard decred min confirmations is 2, this should be used as default for wallet operations
+// provision should me made in individual interface for user to override this default value
+const DefaultRequiredConfirmations = 2
+
 // Wallet defines key functions for performing operations on a decred wallet
 // These functions are implemented by the different mediums that provide access to a decred wallet
 type Wallet interface {
 	// Balance returns account balance for the accountNumbers passed in
 	// or for all accounts if no account number is passed in
-	AccountBalance(accountNumber uint32) (*Balance, error)
+	AccountBalance(accountNumber uint32, requiredConfirmations int32) (*Balance, error)
 
 	// AccountsOverview returns the name, account number and balance for all accounts in wallet
-	AccountsOverview() ([]*Account, error)
+	AccountsOverview(requiredConfirmations int32) ([]*Account, error)
 
 	// NextAccount adds an account to the wallet using the specified name
 	// Returns account number for newly added account
@@ -33,18 +37,18 @@ type Wallet interface {
 
 	// UnspentOutputs lists all unspent outputs in the specified account that sum up to `targetAmount`
 	// If `targetAmount` is 0, all unspent outputs in account are returned
-	UnspentOutputs(account uint32, targetAmount int64) ([]*UnspentOutput, error)
+	UnspentOutputs(account uint32, targetAmount int64, requiredConfirmations int32) ([]*UnspentOutput, error)
 
 	// SendFromAccount sends funds to 1 or more destination addresses, each with a specified amount
 	// The inputs to the transaction are automatically selected from all unspent outputs in the account
 	// Returns the transaction hash as string if successful
-	SendFromAccount(sourceAccount uint32, destinations []txhelper.TransactionDestination, passphrase string) (string, error)
+	SendFromAccount(sourceAccount uint32, requiredConfirmations int32, destinations []txhelper.TransactionDestination, passphrase string) (string, error)
 
 	// SendFromUTXOs sends funds to 1 or more destination addresses, each with a specified amount
 	// SendFromUTXOs also sends any change amount that arises from the transaction to the provided changeDestinations
 	// The inputs to the transaction are unspent outputs in the account, matching the keys sent in []utxoKeys
 	// Returns the transaction hash as string if successful
-	SendFromUTXOs(sourceAccount uint32, utxoKeys []string, txDestinations []txhelper.TransactionDestination, changeDestinations []txhelper.TransactionDestination, passphrase string) (string, error)
+	SendFromUTXOs(sourceAccount uint32, requiredConfirmations int32, utxoKeys []string, txDestinations []txhelper.TransactionDestination, changeDestinations []txhelper.TransactionDestination, passphrase string) (string, error)
 
 	// TransactionHistory
 	TransactionHistory() ([]*Transaction, error)

--- a/app/walletmediums/dcrwalletrpc/walletfunctions.go
+++ b/app/walletmediums/dcrwalletrpc/walletfunctions.go
@@ -17,11 +17,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-// ideally, we should let user provide this info in settings and use the user provided value
-// using a constant now to make it easier to update the code where this value is required/used
-const requiredConfirmations = 0
-
-func (c *WalletPRCClient) AccountBalance(accountNumber uint32) (*walletcore.Balance, error) {
+func (c *WalletPRCClient) AccountBalance(accountNumber uint32, requiredConfirmations int32) (*walletcore.Balance, error) {
 	req := &walletrpc.BalanceRequest{
 		AccountNumber:         accountNumber,
 		RequiredConfirmations: requiredConfirmations,
@@ -41,7 +37,7 @@ func (c *WalletPRCClient) AccountBalance(accountNumber uint32) (*walletcore.Bala
 	}, nil
 }
 
-func (c *WalletPRCClient) AccountsOverview() ([]*walletcore.Account, error) {
+func (c *WalletPRCClient) AccountsOverview(requiredConfirmations int32) ([]*walletcore.Account, error) {
 	accounts, err := c.walletService.Accounts(context.Background(), &walletrpc.AccountsRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("error fetching accounts: %s", err.Error())
@@ -50,7 +46,7 @@ func (c *WalletPRCClient) AccountsOverview() ([]*walletcore.Account, error) {
 	accountsOverview := make([]*walletcore.Account, 0, len(accounts.Accounts))
 
 	for _, acc := range accounts.Accounts {
-		balance, err := c.AccountBalance(acc.AccountNumber)
+		balance, err := c.AccountBalance(acc.AccountNumber, requiredConfirmations)
 		if err != nil {
 			return nil, err
 		}
@@ -156,7 +152,7 @@ func (c *WalletPRCClient) GenerateReceiveAddress(account uint32) (string, error)
 	return nextAddress.Address, nil
 }
 
-func (c *WalletPRCClient) UnspentOutputs(account uint32, targetAmount int64) ([]*walletcore.UnspentOutput, error) {
+func (c *WalletPRCClient) UnspentOutputs(account uint32, targetAmount int64, requiredConfirmations int32) ([]*walletcore.UnspentOutput, error) {
 	utxoStream, err := c.unspentOutputStream(account, targetAmount, requiredConfirmations)
 	if err != nil {
 		return nil, err
@@ -205,7 +201,7 @@ func (c *WalletPRCClient) UnspentOutputs(account uint32, targetAmount int64) ([]
 	return unspentOutputs, nil
 }
 
-func (c *WalletPRCClient) SendFromAccount(sourceAccount uint32, destinations []txhelper.TransactionDestination, passphrase string) (string, error) {
+func (c *WalletPRCClient) SendFromAccount(sourceAccount uint32, requiredConfirmations int32, destinations []txhelper.TransactionDestination, passphrase string) (string, error) {
 	// construct non-change outputs for all recipients
 	outputs := make([]*walletrpc.ConstructTransactionRequest_Output, len(destinations))
 	for i, destination := range destinations {
@@ -237,7 +233,7 @@ func (c *WalletPRCClient) SendFromAccount(sourceAccount uint32, destinations []t
 	return c.signAndPublishTransaction(constructResponse.UnsignedTransaction, passphrase)
 }
 
-func (c *WalletPRCClient) SendFromUTXOs(sourceAccount uint32, utxoKeys []string, txDestinations []txhelper.TransactionDestination, changeDestinations []txhelper.TransactionDestination, passphrase string) (string, error) {
+func (c *WalletPRCClient) SendFromUTXOs(sourceAccount uint32, requiredConfirmations int32, utxoKeys []string, txDestinations []txhelper.TransactionDestination, changeDestinations []txhelper.TransactionDestination, passphrase string) (string, error) {
 	// fetch all utxos in account to extract details for the utxos selected by user
 	// passing 0 as targetAmount to c.unspentOutputStream fetches ALL utxos in account
 	utxoStream, err := c.unspentOutputStream(sourceAccount, 0, requiredConfirmations)

--- a/cli/commands/balance.go
+++ b/cli/commands/balance.go
@@ -16,7 +16,7 @@ type BalanceCommand struct {
 
 // Run runs the `balance` command, displaying the user's account balance.
 func (balanceCommand BalanceCommand) Run(wallet walletcore.Wallet) error {
-	accounts, err := wallet.AccountsOverview()
+	accounts, err := wallet.AccountsOverview(walletcore.DefaultRequiredConfirmations)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/helpers.go
+++ b/cli/commands/helpers.go
@@ -23,7 +23,7 @@ func selectAccount(wallet walletcore.Wallet) (uint32, error) {
 	var err error
 
 	// get send  accounts
-	accounts, err := wallet.AccountsOverview()
+	accounts, err := wallet.AccountsOverview(walletcore.DefaultRequiredConfirmations)
 	if err != nil {
 		return 0, err
 	}

--- a/cli/commands/send.go
+++ b/cli/commands/send.go
@@ -38,7 +38,7 @@ func send(wallet walletcore.Wallet, custom bool) error {
 
 	// check if account has positive non-zero balance before proceeding
 	// if balance is zero, there'd be no unspent outputs to use
-	accountBalance, err := wallet.AccountBalance(sourceAccount)
+	accountBalance, err := wallet.AccountBalance(sourceAccount, walletcore.DefaultRequiredConfirmations)
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func completeCustomSend(wallet walletcore.Wallet, sourceAccount uint32, sendDest
 	var totalInputAmount float64
 
 	// get all utxos in account, pass 0 amount to get all
-	utxos, err := wallet.UnspentOutputs(sourceAccount, 0)
+	utxos, err := wallet.UnspentOutputs(sourceAccount, 0, walletcore.DefaultRequiredConfirmations)
 	if err != nil {
 		return "", err
 	}
@@ -137,7 +137,7 @@ func completeCustomSend(wallet walletcore.Wallet, sourceAccount uint32, sendDest
 	for _, utxo := range utxoSelection {
 		outputKeys = append(outputKeys, utxo.OutputKey)
 	}
-	return wallet.SendFromUTXOs(sourceAccount, outputKeys, sendDestinations, changeOutputDestinations, passphrase)
+	return wallet.SendFromUTXOs(sourceAccount, walletcore.DefaultRequiredConfirmations, outputKeys, sendDestinations, changeOutputDestinations, passphrase)
 }
 
 func completeNormalSend(wallet walletcore.Wallet, sourceAccount uint32, sendDestinations []txhelper.TransactionDestination) (string, error) {
@@ -164,5 +164,5 @@ func completeNormalSend(wallet walletcore.Wallet, sourceAccount uint32, sendDest
 		return "", errors.New("transaction cancelled")
 	}
 
-	return wallet.SendFromAccount(sourceAccount, sendDestinations, passphrase)
+	return wallet.SendFromAccount(sourceAccount, walletcore.DefaultRequiredConfirmations, sendDestinations, passphrase)
 }

--- a/desktop/handlers.go
+++ b/desktop/handlers.go
@@ -49,7 +49,7 @@ func resetVars() {
 func (d *Desktop) BalanceHandler(w *nucular.Window) {
 	// check if already fetched. If so, do not fetch again
 	if accountsResponse == nil && err == nil {
-		accountsResponse, err = d.wallet.AccountsOverview()
+		accountsResponse, err = d.wallet.AccountsOverview(walletcore.DefaultRequiredConfirmations)
 	}
 
 	// draw page
@@ -155,7 +155,7 @@ func (d *Desktop) generateAddressHandler(w *nucular.Window) {
 func (d *Desktop) ReceiveHandler(w *nucular.Window) {
 	// check if already fetched. If so, do not fetch again
 	if accountsResponse == nil && err == nil {
-		accountsResponse, err = d.wallet.AccountsOverview()
+		accountsResponse, err = d.wallet.AccountsOverview(walletcore.DefaultRequiredConfirmations)
 	}
 
 	// draw page
@@ -205,7 +205,7 @@ func (d *Desktop) ReceiveHandler(w *nucular.Window) {
 
 func (d *Desktop) selectUTXOSHandler(w *nucular.Window) {
 	if utxosResponse == nil && err == nil {
-		utxosResponse, err = d.wallet.UnspentOutputs(selectedAccountNumber, 0)
+		utxosResponse, err = d.wallet.UnspentOutputs(selectedAccountNumber, 0, walletcore.DefaultRequiredConfirmations)
 	}
 
 	// draw page
@@ -268,7 +268,7 @@ func (d *Desktop) selectUTXOSHandler(w *nucular.Window) {
 
 func (d *Desktop) SendHandler(w *nucular.Window) {
 	if accountsResponse == nil && err == nil {
-		accountsResponse, err = d.wallet.AccountsOverview()
+		accountsResponse, err = d.wallet.AccountsOverview(walletcore.DefaultRequiredConfirmations)
 	}
 
 	// draw page

--- a/web/routes/handlers.go
+++ b/web/routes/handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/go-chi/chi"
 	"github.com/raedahgroup/dcrlibwallet/txhelper"
+	"github.com/raedahgroup/godcr/app/walletcore"
 	qrcode "github.com/skip2/go-qrcode"
 )
 
@@ -41,7 +42,7 @@ func (routes *Routes) createWallet(res http.ResponseWriter, req *http.Request) {
 }
 
 func (routes *Routes) balancePage(res http.ResponseWriter, req *http.Request) {
-	accounts, err := routes.walletMiddleware.AccountsOverview()
+	accounts, err := routes.walletMiddleware.AccountsOverview(walletcore.DefaultRequiredConfirmations)
 	if err != nil {
 		routes.renderError(fmt.Sprintf("Error fetching account balance: %s", err.Error()), res)
 		return
@@ -55,7 +56,7 @@ func (routes *Routes) balancePage(res http.ResponseWriter, req *http.Request) {
 }
 
 func (routes *Routes) sendPage(res http.ResponseWriter, req *http.Request) {
-	accounts, err := routes.walletMiddleware.AccountsOverview()
+	accounts, err := routes.walletMiddleware.AccountsOverview(walletcore.DefaultRequiredConfirmations)
 	if err != nil {
 		routes.renderError(fmt.Sprintf("Error fetching accounts: %s", err.Error()), res)
 		return
@@ -122,9 +123,9 @@ func (routes *Routes) submitSendTxForm(res http.ResponseWriter, req *http.Reques
 			Address: changeAddress,
 		}}
 
-		txHash, err = routes.walletMiddleware.SendFromUTXOs(sourceAccount, utxos, sendDestinations, changeDestinations, passphrase)
+		txHash, err = routes.walletMiddleware.SendFromUTXOs(sourceAccount, walletcore.DefaultRequiredConfirmations, utxos, sendDestinations, changeDestinations, passphrase)
 	} else {
-		txHash, err = routes.walletMiddleware.SendFromAccount(sourceAccount, sendDestinations, passphrase)
+		txHash, err = routes.walletMiddleware.SendFromAccount(sourceAccount, walletcore.DefaultRequiredConfirmations, sendDestinations, passphrase)
 	}
 
 	if err != nil {
@@ -136,7 +137,7 @@ func (routes *Routes) submitSendTxForm(res http.ResponseWriter, req *http.Reques
 }
 
 func (routes *Routes) receivePage(res http.ResponseWriter, req *http.Request) {
-	accounts, err := routes.walletMiddleware.AccountsOverview()
+	accounts, err := routes.walletMiddleware.AccountsOverview(walletcore.DefaultRequiredConfirmations)
 	if err != nil {
 		routes.renderError(fmt.Sprintf("Error fetching accounts: %s", err.Error()), res)
 		return
@@ -195,7 +196,7 @@ func (routes *Routes) getUnspentOutputs(res http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	utxos, err := routes.walletMiddleware.UnspentOutputs(uint32(accountNumber), 0)
+	utxos, err := routes.walletMiddleware.UnspentOutputs(uint32(accountNumber), 0, walletcore.DefaultRequiredConfirmations)
 	if err != nil {
 		data["success"] = false
 		data["message"] = err.Error()


### PR DESCRIPTION
Closes #125 

The following core functions require a `min. confirmations` or `required confirmations` value in carrying out their operations:
- AccountBalance (balance returned depends on value of required confirmations)
- AccountsOverview (returns all accounts with their balances, the balances depend on the value of required confirmations)
- UnspentOutputs (returns utxos in an account with confirmation higher than or equal to a specified min. conf. parameter)
- SendFromAccount (uses the value of req. confirmations in selecting inputs for the new transaction)
- SendFromUTXOs (uses the value of req. confirmations in selecting inputs for the new transaction)

Prior to this PR, these core functions always use a constant value (0) for minimum/required confirmations. This PR changes that behaviour, allowing different interfaces to specify a value to use for required/min confirmations for each function.

Currently, all interfaces use a new default value (2) but this will change going forward especially in PR #118 and in the fix to issue #138, where the cli and web interfaces will need to use a `req confirmations` value other than the default value of 2.