### PR TITLE
create new config file if missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,16 @@ $ GO111MODULE=on go install
 ```
 
 ## Running godcr
-* Create the godcr configuration file by copying the sample configuration file (`sample-godcr.conf`) to the default config location and editing as necessary. The default config location can be gotten by running `godcr -h`.
-The settings in the configuration file can also be provided on the command line as options to the program. Flags passed on the command line override those set in the configuration file. Run `godcr -h` to see the available options.
-* Once you've configured godcr, you can perform various wallet-related operations by running
+### General usage
+You can perform various wallet-related operations by running
 ```bash
 $ godcr [options] <command> [args]
 ```
-* To view available commands and options at any time:
-```bash
-$ godcr -h
-```
-* To get detailed help information for a command:
-```bash
-$ godcr <command> -h
+
+### Commands and options
+* Use `godcr -h` or `godcr help` to view options, commands and path to the godcr config file
+* Some options can only be set in the godcr configuration (godcr.conf) file. Those options are not displayed in the output of `godcr -h`. Edit the config file to view and set those options.
+* Use `godcr <command> -h` or `godcr help <command>` to view command args and detailed help information for a command
 ```
 
 ## Contributing 

--- a/app/config/godcr.conf.go
+++ b/app/config/godcr.conf.go
@@ -1,0 +1,44 @@
+package config
+
+const configTextTemplate = `[Application Options]
+
+; ------------------------------------------------------------------------------
+; App Data
+; ------------------------------------------------------------------------------
+
+; Path to application data directory.
+appdata={{.AppDataDir}}
+
+; ------------------------------------------------------------------------------
+; Network settings
+; ------------------------------------------------------------------------------
+
+; Connect to a running drcwallet daemon over rpc to perform wallet operations.
+; By default godcr uses dcrlibwallet (usewalletrpc=false or usewalletrpc=0).
+; You can switch to dcrwallet rpc using (usewalletrpc=true or usewalletrpc=1).
+; usewalletrpc=false
+
+; Wallet gRPC server address. Required if usewalletrpc=true
+; walletrpcserver=localhost:19111
+
+; Disable TLS for rpc connection (nowalletrpctls=1) or specify path to dcrwallet's RPC certificate
+; nowalletrpctls=0
+walletrpccert={{.WalletRPCCert}}
+
+; Connects to testnet wallet instead of mainnet
+; testnet=false
+
+; ------------------------------------------------------------------------------
+; Godcr Interface Modes
+; ------------------------------------------------------------------------------
+
+; godcr can run in any of the following modes: cli, http, desktop
+; mode=cli
+
+; ------------------------------------------------------------------------------
+; Godcr HTTP Mode Options
+; ------------------------------------------------------------------------------
+
+; Host and port for godcr http server when mode=http
+httphost={{.HTTPHost}}
+httpport={{.HTTPPort}}`

--- a/desktop/walletloader.go
+++ b/desktop/walletloader.go
@@ -11,9 +11,6 @@ import (
 // this method may stall until previous godcr instances are closed (especially in cases of multiple dcrlibwallet instances)
 // hence the need for ctx, so user can cancel the operation if it's taking too long
 func openWalletIfExist(ctx context.Context, walletMiddleware app.WalletMiddleware) (walletExists bool, err error) {
-	// notify user of the current operation so if takes too long, they have an idea what the cause is
-	fmt.Println("Opening wallet...")
-
 	var errMsg string
 	loadWalletDone := make(chan bool)
 

--- a/web/server.go
+++ b/web/server.go
@@ -56,9 +56,6 @@ func StartHttpServer(ctx context.Context, walletMiddleware app.WalletMiddleware,
 // this method may stall until previous godcr instances are closed (especially in cases of multiple dcrlibwallet instances)
 // hence the need for ctx, so user can cancel the operation if it's taking too long
 func openWalletIfExist(ctx context.Context, walletMiddleware app.WalletMiddleware) error {
-	// notify user of the current operation so if takes too long, they have an idea what the cause is
-	fmt.Println("Opening wallet...")
-
 	var err error
 	var errMsg string
 	loadWalletDone := make(chan bool)


### PR DESCRIPTION
Resolves [Issue 144](https://github.com/raedahgroup/godcr/issues/144)
Currently, if the godcr.conf file is not found in the app data dir, the godcr program displays an error message similar to this:
`open ~/godcr/godcr.conf: no such file or directory`
This PR solve this solves this problem by creating a new config file using the default values and notifies the user of the action.
![missing-config](https://user-images.githubusercontent.com/11990092/50873797-b9e63b00-13c1-11e9-828e-e7f5f687929d.png)
