### PR TITLE
ask to start dcrwallet if it isn't currently running

### DIFF
--- a/app/walletmediums/dcrwalletrpc/dcrwalletrpc.go
+++ b/app/walletmediums/dcrwalletrpc/dcrwalletrpc.go
@@ -33,7 +33,7 @@ type rpcConnectionResult struct {
 }
 
 const (
-	dcrdExecutableName = "dcrd"
+	dcrdExecutableName      = "dcrd"
 	dcrwalletExecutableName = "dcrwallet"
 )
 
@@ -78,7 +78,7 @@ func startDcrwallet() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("started dcrwallet",)
+	fmt.Println("started dcrwallet")
 
 	return nil
 }
@@ -93,7 +93,7 @@ func ensureDcrdIsRunning() error {
 	}
 	fmt.Println("starting dcrd...")
 
-	cmd := exec.Command(dcrwalletExecutableName,)
+	cmd := exec.Command(dcrwalletExecutableName)
 	err = cmd.Start()
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/raedahgroup/godcr
 
 require (
 	github.com/aarzilli/nucular v0.0.0-20181227101716-d1a942545d6d
+	github.com/ademuanthony/ps v1.0.1
 	github.com/decred/dcrd/chaincfg v1.2.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrutil v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522221800-27f122750802 h1:otE7gFP0KwnPTKtM
 github.com/BurntSushi/xgb v0.0.0-20160522221800-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/aarzilli/nucular v0.0.0-20181227101716-d1a942545d6d h1:BLhrKkQNOBeRDRJdevy7tE7ca2+sp3daQ6xG7vagEzg=
 github.com/aarzilli/nucular v0.0.0-20181227101716-d1a942545d6d/go.mod h1:rh/rFeChsox144sAUJaD7obyj+JFIUqag6QnvRyAZJQ=
+github.com/ademuanthony/ps v1.0.1 h1:3PTXrGGO+98XD1jFddHyzeo8Y9RtBPj7WTzriFXvjGE=
+github.com/ademuanthony/ps v1.0.1/go.mod h1:ca3JSHcNMcgAxkHhBgPCHYZGzfpm2gDublbqXLnzZUk=
 github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=


### PR DESCRIPTION
Resolved [Issue 90](https://github.com/raedahgroup/godcr/issues/90)

The user is notified of dcrwallet not running and asked if he would like to have it started automatically. If in the process of starting dcrwallet, dcrd is also found not to be started, it will be automatically started as well

![auto-start-dcrwallet](https://user-images.githubusercontent.com/11990092/51365020-98323580-1ade-11e9-9baa-f48282dba328.png)
