### PR TITLE
fix nuklear app launch

### DIFF
--- a/nuklear/desktop.go
+++ b/nuklear/desktop.go
@@ -30,7 +30,7 @@ func LaunchApp(ctx context.Context, walletMiddleware app.WalletMiddleware) error
 	desktop := &Desktop{
 		walletMiddleware: walletMiddleware,
 		pageChanged:      true,
-		currentPage:      "send",
+		currentPage:      "sync",
 	}
 
 	// initialize master window and set style


### PR DESCRIPTION
A recent PR mistakenly set the start page of the nuklear app to send. This PR corrects that to sync.