### PR TITLE
Transaction details nuklear

### DIFF
--- a/nuklear/pagehandlers/history.go
+++ b/nuklear/pagehandlers/history.go
@@ -151,7 +151,7 @@ func (handler *HistoryHandler) renderTransactionDetailsPage(window *nucular.Wind
 }
 
 func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.Window) {
-	contentWindow.Window.Row(0).Static(670, 700)
+	contentWindow.Window.Row(handler.calculateTxDetailsPageHeight()).Static(670, 700)
 	widgets.NoScrollGroupWindow("Transaction details column one", contentWindow.Window, func(window *widgets.Window) {
 		table := widgets.NewTable()
 		table.AddRow(
@@ -176,7 +176,7 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 		)
 		table.Render(window)
 
-		window.AddHorizontalSpace(50)
+		window.AddHorizontalSpace(30)
 
 		window.AddLabelWithFont("Inputs", "LC", styles.BoldPageContentFont)
 
@@ -219,7 +219,7 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 		)
 		table.Render(window)
 
-		window.AddHorizontalSpace(50)
+		window.AddHorizontalSpace(30)
 
 		window.AddLabelWithFont("Outputs", "LC", styles.BoldPageContentFont)
 
@@ -248,4 +248,19 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 		}
 		table.Render(window)
 	})
+}
+
+func (handler *HistoryHandler) calculateTxDetailsPageHeight() int {
+	firstSectionHeight := 240
+	outputsLen := len(handler.transactionDetails.Outputs)
+	inputsLen := len(handler.transactionDetails.Inputs)
+
+	var secondSectionLines int
+	if outputsLen > inputsLen {
+		secondSectionLines = outputsLen
+	} else {
+		secondSectionLines = inputsLen
+	}
+
+	return firstSectionHeight + (secondSectionLines * 27)
 }

--- a/nuklear/pagehandlers/history.go
+++ b/nuklear/pagehandlers/history.go
@@ -143,6 +143,10 @@ func (handler *HistoryHandler) renderTransactionDetailsPage(window *nucular.Wind
 	}
 
 	widgets.PageContentWindowDefaultPadding("Transaction Details", window, func(contentWindow *widgets.Window) {
+		contentWindow.AddButton("Back", func() {
+			handler.goBackToHistory(contentWindow)
+		})
+
 		if handler.fetchTxDetailsError != nil {
 			contentWindow.DisplayErrorMessage("Error fetching transaction details", handler.fetchTxDetailsError)
 		} else if handler.selectedTxDetails != nil {
@@ -151,6 +155,11 @@ func (handler *HistoryHandler) renderTransactionDetailsPage(window *nucular.Wind
 			contentWindow.DisplayIsLoadingMessage()
 		}
 	})
+}
+
+func (handler *HistoryHandler) goBackToHistory(contentWindow *widgets.Window) {
+	handler.clearTxDetails()
+	contentWindow.Master().Changed()
 }
 
 func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.Window) {

--- a/nuklear/pagehandlers/history.go
+++ b/nuklear/pagehandlers/history.go
@@ -3,8 +3,10 @@ package pagehandlers
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/aarzilli/nucular"
+	"github.com/decred/dcrd/dcrutil"
 	"github.com/raedahgroup/godcr/app/walletcore"
 	"github.com/raedahgroup/godcr/nuklear/styles"
 	"github.com/raedahgroup/godcr/nuklear/widgets"
@@ -16,6 +18,12 @@ type HistoryHandler struct {
 	transactions           []*walletcore.Transaction
 	isFetchingTransactions bool
 	nextBlockHeight        int32
+
+	transactionHash              string
+	transactionDetails           *walletcore.TransactionDetails
+	isFetchingTransactionDetails bool
+
+	wallet walletcore.Wallet
 }
 
 func (handler *HistoryHandler) BeforeRender(wallet walletcore.Wallet, refreshWindowDisplay func()) bool {
@@ -26,12 +34,26 @@ func (handler *HistoryHandler) BeforeRender(wallet walletcore.Wallet, refreshWin
 	handler.err = nil
 	handler.transactions = nil
 
+	handler.transactionHash = ""
+	handler.transactionDetails = nil
+	handler.isFetchingTransactionDetails = false
+
+	handler.wallet = wallet
+
 	go handler.fetchTransactions(wallet, refreshWindowDisplay)
 
 	return true
 }
 
 func (handler *HistoryHandler) Render(window *nucular.Window) {
+	if handler.transactionHash == "" {
+		handler.renderHistoryPage(window)
+		return
+	}
+	handler.renderTransactionDetailsPage(window)
+}
+
+func (handler *HistoryHandler) renderHistoryPage(window *nucular.Window) {
 	widgets.PageContentWindowDefaultPadding("History", window, func(contentWindow *widgets.Window) {
 		if handler.err != nil {
 			contentWindow.DisplayErrorMessage("Error fetching txs", handler.err)
@@ -92,9 +114,138 @@ func (handler *HistoryHandler) displayTransactions(contentWindow *widgets.Window
 			widgets.NewLabelTableCell(tx.Amount, "RC"),
 			widgets.NewLabelTableCell(tx.Fee, "RC"),
 			widgets.NewLabelTableCell(tx.Type, "LC"),
-			widgets.NewLabelTableCell(tx.Hash, "LC"),
+			widgets.NewLinkTableCell(tx.Hash, "Click to see transaction details", handler.gotoTransactionDetails),
 		)
 	}
 
 	historyTable.Render(contentWindow)
+}
+
+func (handler *HistoryHandler) gotoTransactionDetails(txHash string, window *widgets.Window) {
+	handler.transactionHash = txHash
+	window.Master().Changed()
+}
+
+func (handler *HistoryHandler) renderTransactionDetailsPage(window *nucular.Window) {
+	if handler.transactionDetails == nil {
+		handler.isFetchingTransactionDetails = true
+		go func() {
+			handler.transactionDetails, handler.err = handler.wallet.GetTransaction(handler.transactionHash)
+			handler.isFetchingTransactionDetails = false
+			window.Master().Changed()
+		}()
+	}
+
+	widgets.PageContentWindowDefaultPadding("Transaction Detail", window, func(contentWindow *widgets.Window) {
+		if handler.err != nil {
+			contentWindow.DisplayErrorMessage("Error fetching transaction details", handler.err)
+		} else if handler.transactionDetails != nil {
+			handler.displayTransactionDetails(contentWindow)
+		}
+
+		// show loading indicator if tx details is being fetched
+		if handler.isFetchingTransactionDetails {
+			contentWindow.DisplayIsLoadingMessage()
+		}
+	})
+}
+
+func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.Window) {
+	contentWindow.Window.Row(0).Static(670, 700)
+	widgets.NoScrollGroupWindow("Transaction details column one", contentWindow.Window, func(window *widgets.Window) {
+		table := widgets.NewTable()
+		table.AddRow(
+			widgets.NewLabelTableCell("Confirmations", "LC"),
+			widgets.NewLabelTableCell(strconv.Itoa(int(handler.transactionDetails.Confirmations)), "LC"),
+		)
+		table.AddRow(
+			widgets.NewLabelTableCell("Hash", "LC"),
+			widgets.NewLabelTableCell(handler.transactionDetails.Hash, "LC"),
+		)
+		table.AddRow(
+			widgets.NewLabelTableCell("Block Height", "LC"),
+			widgets.NewLabelTableCell(strconv.Itoa(int(handler.transactionDetails.BlockHeight)), "LC"),
+		)
+		table.AddRow(
+			widgets.NewLabelTableCell("Direction", "LC"),
+			widgets.NewLabelTableCell(handler.transactionDetails.Direction.String(), "LC"),
+		)
+		table.AddRow(
+			widgets.NewLabelTableCell("Type", "LC"),
+			widgets.NewLabelTableCell(handler.transactionDetails.Type, "LC"),
+		)
+		table.Render(window)
+
+		window.AddHorizontalSpace(50)
+
+		window.AddLabelWithFont("Inputs", "LC", styles.BoldPageContentFont)
+
+		table = widgets.NewTable()
+		table.AddRowWithFont(styles.NavFont,
+			widgets.NewLabelTableCell("Previous Outpoint", "LC"),
+			widgets.NewLabelTableCell("Amount", "LC"),
+		)
+
+		for _, input := range handler.transactionDetails.Inputs {
+			table.AddRow(
+				widgets.NewLabelTableCell(input.PreviousTransactionHash, "LC"),
+				widgets.NewLabelTableCell(dcrutil.Amount(input.AmountIn).String(), "LC"),
+			)
+		}
+		table.Render(window)
+	})
+
+	widgets.NoScrollGroupWindow("Transaction details column two", contentWindow.Window, func(window *widgets.Window) {
+		table := widgets.NewTable()
+		table.AddRow(
+			widgets.NewLabelTableCell("Amount", "LC"),
+			widgets.NewLabelTableCell(handler.transactionDetails.Amount, "LC"),
+		)
+		table.AddRow(
+			widgets.NewLabelTableCell("Size", "LC"),
+			widgets.NewLabelTableCell(strconv.Itoa(handler.transactionDetails.Size)+" Bytes", "LC"),
+		)
+		table.AddRow(
+			widgets.NewLabelTableCell("Fee", "LC"),
+			widgets.NewLabelTableCell(handler.transactionDetails.Fee, "LC"),
+		)
+		table.AddRow(
+			widgets.NewLabelTableCell("Fee Rate", "LC"),
+			widgets.NewLabelTableCell(handler.transactionDetails.FeeRate.String(), "LC"),
+		)
+		table.AddRow(
+			widgets.NewLabelTableCell("Time", "LC"),
+			widgets.NewLabelTableCell(handler.transactionDetails.FormattedTime, "LC"),
+		)
+		table.Render(window)
+
+		window.AddHorizontalSpace(50)
+
+		window.AddLabelWithFont("Outputs", "LC", styles.BoldPageContentFont)
+
+		table = widgets.NewTable()
+		table.AddRowWithFont(styles.NavFont,
+			widgets.NewLabelTableCell("Address", "LC"),
+			widgets.NewLabelTableCell("Account", "LC"),
+			widgets.NewLabelTableCell("Value", "LC"),
+			widgets.NewLabelTableCell("Type", "LC"),
+		)
+
+		for _, output := range handler.transactionDetails.Outputs {
+			for _, address := range output.Addresses {
+				account := address.AccountName
+				if !address.IsMine {
+					account = "external address"
+				}
+
+				table.AddRow(
+					widgets.NewLabelTableCell(address.Address, "LC"),
+					widgets.NewLabelTableCell(account, "LC"),
+					widgets.NewLabelTableCell(dcrutil.Amount(output.Value).String(), "LC"),
+					widgets.NewLabelTableCell(output.ScriptType, "LC"),
+				)
+			}
+		}
+		table.Render(window)
+	})
 }

--- a/nuklear/styles/styles.go
+++ b/nuklear/styles/styles.go
@@ -39,6 +39,12 @@ func MasterWindowStyle() *style.Style {
 	// style checkbox
 	masterWindowStyle.Checkbox.Padding = noPadding
 
+	// style link selectable
+	masterWindowStyle.Selectable.Padding = noPadding
+	masterWindowStyle.Selectable.TextNormal = DecredDarkBlueColor
+	masterWindowStyle.Selectable.TextHover = DecredLightBlueColor
+	masterWindowStyle.Selectable.TextPressed = DecredLightBlueColor
+
 	return masterWindowStyle
 }
 

--- a/nuklear/styles/styles.go
+++ b/nuklear/styles/styles.go
@@ -39,7 +39,7 @@ func MasterWindowStyle() *style.Style {
 	// style checkbox
 	masterWindowStyle.Checkbox.Padding = noPadding
 
-	// style link selectable
+	// style selectable labels (links)
 	masterWindowStyle.Selectable.Padding = noPadding
 	masterWindowStyle.Selectable.TextNormal = DecredDarkBlueColor
 	masterWindowStyle.Selectable.TextHover = DecredLightBlueColor

--- a/nuklear/widgets/tablecell.go
+++ b/nuklear/widgets/tablecell.go
@@ -77,23 +77,23 @@ func (checkbox *CheckboxTableCell) MinWidth(window *Window) int {
 type LinkTableCell struct {
 	text        string
 	tooltipText string
-	value       *bool
+	selected    *bool
 	clickFunc   func(text string, window *Window)
 }
 
 func NewLinkTableCell(text, tooltipText string, clickFunc func(text string, window *Window)) *LinkTableCell {
-	val := false
+	selected := false
 
 	return &LinkTableCell{
 		text:        text,
 		tooltipText: tooltipText,
-		value:       &val,
+		selected:    &selected,
 		clickFunc:   clickFunc,
 	}
 }
 
 func (link *LinkTableCell) Render(window *Window) {
-	if window.SelectableLabel(link.text, "LC", link.value) {
+	if window.SelectableLabel(link.text, "LC", link.selected) {
 		link.clickFunc(link.text, window)
 	}
 	if link.tooltipText != "" {

--- a/nuklear/widgets/tablecell.go
+++ b/nuklear/widgets/tablecell.go
@@ -73,3 +73,36 @@ func (checkbox *CheckboxTableCell) Render(window *Window) {
 func (checkbox *CheckboxTableCell) MinWidth(window *Window) int {
 	return window.LabelWidth(checkbox.label) + 16 // assumed width of check box
 }
+
+type LinkTableCell struct {
+	text        string
+	tooltipText string
+	value       *bool
+	clickFunc   func(text string, window *Window)
+}
+
+func NewLinkTableCell(text, tooltipText string, clickFunc func(text string, window *Window)) *LinkTableCell {
+	val := false
+
+	return &LinkTableCell{
+		text:        text,
+		tooltipText: tooltipText,
+		value:       &val,
+		clickFunc:   clickFunc,
+	}
+}
+
+func (link *LinkTableCell) Render(window *Window) {
+	if window.SelectableLabel(link.text, "LC", link.value) {
+		link.clickFunc(link.text, window)
+	}
+	if link.tooltipText != "" {
+		if window.Input().Mouse.HoveringRect(window.LastWidgetBounds) {
+			window.Tooltip(link.tooltipText)
+		}
+	}
+}
+
+func (link *LinkTableCell) MinWidth(window *Window) int {
+	return window.LabelWidth(link.text)
+}


### PR DESCRIPTION
This adds a transaction details page to the nuklear interface.
![Screenshot from 2019-03-27 11-59-32](https://user-images.githubusercontent.com/42093751/55071412-d91f6b00-5088-11e9-9301-61b33ab98133.png)



