### PR TITLE
fix: cli - read input from terminal

### DIFF
--- a/cli/termio/terminalprompt/getinput.go
+++ b/cli/termio/terminalprompt/getinput.go
@@ -29,7 +29,7 @@ func getTextInput(prompt string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimRight(text, "\n"), nil
+	return strings.TrimSuffix(text, "\n"), nil
 }
 
 // getPasswordInput - Prompt for password.

--- a/cli/termio/terminalprompt/getinput.go
+++ b/cli/termio/terminalprompt/getinput.go
@@ -29,7 +29,11 @@ func getTextInput(prompt string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSuffix(text, "\n"), nil
+	
+	text = strings.TrimSuffix(text, "\n")
+	text = strings.TrimSuffix(text, "\r")
+	
+	return text, nil
 }
 
 // getPasswordInput - Prompt for password.


### PR DESCRIPTION
Fixes #220 and #238. Issue is only known to affect Windows OS. User input gotten from the terminal/command prompt contains line break characters that ought to be trimmed off.