### PR TITLE
Account selection widget

### DIFF
--- a/nuklear/handlers/receive.go
+++ b/nuklear/handlers/receive.go
@@ -35,7 +35,7 @@ func (handler *ReceiveHandler) BeforeRender() {
 func (handler *ReceiveHandler) Render(window *nucular.Window, wallet walletcore.Wallet) {
 	if !handler.isRendering {
 		handler.isRendering = true
-		accounts, err := walletMiddleware.AccountsOverview(walletcore.DefaultRequiredConfirmations)
+		accounts, err := wallet.AccountsOverview(walletcore.DefaultRequiredConfirmations)
 		if err != nil {
 			handler.err = err
 		} else {
@@ -61,7 +61,7 @@ func (handler *ReceiveHandler) Render(window *nucular.Window, wallet walletcore.
 				}
 
 				if handler.numAccounts == 1 && handler.generatedAddress == "" {
-					handler.generatedAddress, handler.err = walletMiddleware.ReceiveAddress(handler.accountSelector.GetSelectedAccountNumber())
+					handler.generatedAddress, handler.err = wallet.ReceiveAddress(handler.accountSelector.GetSelectedAccountNumber())
 					handler.RenderAddress(contentWindow)
 				} else {
 					handler.accountSelector.Render(contentWindow.Window)
@@ -69,7 +69,7 @@ func (handler *ReceiveHandler) Render(window *nucular.Window, wallet walletcore.
 					// draw submit button
 					if contentWindow.Button(label.T(buttonLabel), false) {
 						// get address
-						handler.generatedAddress, handler.err = walletMiddleware.ReceiveAddress(handler.accountSelector.GetSelectedAccountNumber())
+						handler.generatedAddress, handler.err = wallet.ReceiveAddress(handler.accountSelector.GetSelectedAccountNumber())
 						if handler.err != nil {
 							contentWindow.SetErrorMessage(handler.err.Error())
 						} else {

--- a/nuklear/handlers/sync.go
+++ b/nuklear/handlers/sync.go
@@ -38,9 +38,6 @@ func (s *SyncHandler) Render(window *nucular.Window, wallet app.WalletMiddleware
 		return
 	}
 
-	changePage("balance")
-	return
-
 	if contentWindow := helpers.NewWindow("Sync page", window, 0); contentWindow != nil {
 		if s.err != nil {
 			contentWindow.Row(50).Dynamic(1)

--- a/nuklear/handlers/sync.go
+++ b/nuklear/handlers/sync.go
@@ -38,6 +38,9 @@ func (s *SyncHandler) Render(window *nucular.Window, wallet app.WalletMiddleware
 		return
 	}
 
+	changePage("balance")
+	return
+
 	if contentWindow := helpers.NewWindow("Sync page", window, 0); contentWindow != nil {
 		if s.err != nil {
 			contentWindow.Row(50).Dynamic(1)

--- a/nuklear/handlers/widgets/account-selection.go
+++ b/nuklear/handlers/widgets/account-selection.go
@@ -1,0 +1,62 @@
+package widgets
+
+import (
+	"github.com/aarzilli/nucular"
+	"github.com/raedahgroup/godcr/app/walletcore"
+)
+
+type AccountSelection struct {
+	accounts   []*walletcore.Account
+	comboItems []string
+
+	selectedAccountIndex int
+}
+
+func NewAccountSelectionWidget(accounts []*walletcore.Account) *AccountSelection {
+	comboItems := make([]string, len(accounts))
+	for index, account := range accounts {
+		comboItems[index] = account.String()
+	}
+
+	return &AccountSelection{
+		accounts:             accounts,
+		comboItems:           comboItems,
+		selectedAccountIndex: 0,
+	}
+}
+
+func (a *AccountSelection) Render(window *nucular.Window) {
+	if len(a.accounts) > 1 {
+		a.selectedAccountIndex = window.ComboSimple(a.comboItems, a.selectedAccountIndex, 30)
+	} else {
+		account := a.accounts[0]
+		a.selectedAccountIndex = 0
+		window.Label(account.String(), "LC")
+	}
+}
+
+func (a *AccountSelection) GetSelectedAccount() *walletcore.Account {
+	accountName := a.comboItems[a.selectedAccountIndex]
+	for _, account := range a.accounts {
+		if account.Name == accountName {
+			return account
+		}
+	}
+
+	return nil
+}
+
+func (a *AccountSelection) GetSelectedAccountNumber() uint32 {
+	selectedAccount := a.GetSelectedAccount()
+	if selectedAccount != nil {
+		return selectedAccount.Number
+	}
+
+	return 0
+}
+
+func (a *AccountSelection) Reset() {
+	if len(a.accounts) > 1 {
+		a.selectedAccountIndex = 0
+	}
+}

--- a/nuklear/helpers/style.go
+++ b/nuklear/helpers/style.go
@@ -151,6 +151,26 @@ func SetStandaloneWindowStyle(window nucular.MasterWindow) {
 	window.SetStyle(style)
 }
 
+func StyleClipboardInput(window *Window) {
+	style := window.Master().Style()
+	style.Font = PageContentFont
+	style.Edit.Border = 0
+	style.Edit.Normal.Data.Color = contentBackgroundColor
+	style.Edit.Hover.Data.Color = contentBackgroundColor
+	style.Edit.Active.Data.Color = contentBackgroundColor
+	window.Master().SetStyle(style)
+}
+
+func ResetInputStyle(window *Window) {
+	style := window.Master().Style()
+	style.Font = PageContentFont
+	style.Edit.Border = 1
+	style.Edit.Normal.Data.Color = whiteColor
+	style.Edit.Hover.Data.Color = whiteColor
+	style.Edit.Active.Data.Color = whiteColor
+	window.Master().SetStyle(style)
+}
+
 func AmountToString(amount float64) string {
 	amount = math.Round(amount)
 	return fmt.Sprintf("%d DCR", int(amount))


### PR DESCRIPTION
This creates a reusable account selection widget. The widget displays as just text when the wallet has just one account, and displays a combo if the wallet has multiple accounts.

It also auto generates a receive address on the receive page if the wallet has just one account
![Screenshot from 2019-04-03 09-52-43](https://user-images.githubusercontent.com/42093751/55466246-b7793300-55f6-11e9-8d2b-47992f473fe1.png)
![Screenshot from 2019-04-03 09-52-59](https://user-images.githubusercontent.com/42093751/55466248-b7793300-55f6-11e9-8490-4fbd25b58c53.png)

