### PR TITLE
improved cli balance command

### DIFF
--- a/app/walletmediums/dcrwalletrpc/walletfunctions.go
+++ b/app/walletmediums/dcrwalletrpc/walletfunctions.go
@@ -236,7 +236,7 @@ func (c *WalletRPCClient) SendFromAccount(sourceAccount uint32, requiredConfirma
 	for i, output := range outputs {
 		walletrpcOutputs[i] = &walletrpc.ConstructTransactionRequest_Output{
 			Destination: &walletrpc.ConstructTransactionRequest_OutputDestination{
-				Script: output.PkScript,
+				Script:        output.PkScript,
 				ScriptVersion: uint32(output.Version),
 			},
 			Amount: output.Value,

--- a/cli/commands/balance.go
+++ b/cli/commands/balance.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/raedahgroup/godcr/app/walletcore"
 	"github.com/raedahgroup/godcr/cli/termio"
@@ -11,7 +10,6 @@ import (
 // Balance displays the user's account balance.
 type BalanceCommand struct {
 	commanderStub
-	Detailed bool `short:"d" long:"detailed" description:"Display detailed account balance report"`
 }
 
 // Run runs the `balance` command, displaying the user's account balance.
@@ -21,47 +19,65 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 		return err
 	}
 
-	if balanceCommand.Detailed {
-		showDetailedBalance(accounts)
+	var columns []string
+
+	if len(accounts) == 1 {
+		rows := make([][]interface{}, 1)
+		rows[0] = []interface{}{}
+
+		if accounts[0].Balance.Total == accounts[0].Balance.Spendable {
+			columns = append(columns, "Total")
+			rows[0] = append(rows[0], accounts[0].Balance.Total)
+		} else {
+			columns = append(columns, "Total", "Spendable")
+			rows[0] = append(rows[0], accounts[0].Balance.Total)
+			rows[0] = append(rows[0], accounts[0].Balance.Spendable)
+		}
+		if accounts[0].Balance.LockedByTickets != 0 {
+			columns = append(columns, "Locked By Tickets")
+			rows[0] = append(rows[0], accounts[0].Balance.LockedByTickets)
+		}
+		if accounts[0].Balance.VotingAuthority != 0 {
+			columns = append(columns, "Voting Authority")
+			rows[0] = append(rows[0], accounts[0].Balance.VotingAuthority)
+		}
+		if accounts[0].Balance.Unconfirmed != 0 {
+			columns = append(columns, "Unconfirmed")
+			rows[0] = append(rows[0], accounts[0].Balance.Unconfirmed)
+		}
+
+		termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
 	} else {
-		showBalanceSummary(accounts)
+		rows := make([][]interface{}, len(accounts))
+		for i, account := range accounts {
+			rows[i] = []interface{}{}
+
+			columns = append(columns, "Account")
+			rows[i] = append(rows[i], account.Name)
+			if account.Balance.Total == account.Balance.Spendable {
+				columns = append(columns, "Total")
+				rows[i] = append(rows[i], account.Balance.Total)
+			} else {
+				columns = append(columns, " Total", "Spendable")
+				rows[i] = append(rows[i], account.Balance.Total)
+				rows[i] = append(rows[i], account.Balance.Spendable)
+			}
+			if account.Balance.LockedByTickets != 0 {
+				columns = append(columns, "Locked By Tickets")
+				rows[i] = append(rows[i], account.Balance.LockedByTickets)
+			}
+			if account.Balance.VotingAuthority != 0 {
+				columns = append(columns, "Voting Authority")
+				rows[i] = append(rows[i], account.Balance.VotingAuthority)
+			}
+			if account.Balance.Unconfirmed != 0 {
+				columns = append(columns, "Unconfirmed")
+				rows[i] = append(rows[i], account.Balance.Unconfirmed)
+			}
+		}
+		
+		termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
 	}
 
 	return nil
-}
-
-func showDetailedBalance(accountBalances []*walletcore.Account) {
-	columns := []string{
-		"Account",
-		"Total",
-		"Spendable",
-		"Locked By Tickets",
-		"Voting Authority",
-		"Unconfirmed",
-	}
-	rows := make([][]interface{}, len(accountBalances))
-	for i, account := range accountBalances {
-		rows[i] = []interface{}{
-			account.Name,
-			account.Balance.Total,
-			account.Balance.Spendable,
-			account.Balance.LockedByTickets,
-			account.Balance.VotingAuthority,
-			account.Balance.Unconfirmed,
-		}
-	}
-	termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
-}
-
-func showBalanceSummary(accounts []*walletcore.Account) {
-	if len(accounts) == 1 {
-		commandOutput := accounts[0].String()
-		termio.PrintStringResult(commandOutput)
-	} else {
-		commandOutput := make([]string, len(accounts))
-		for i, account := range accounts {
-			commandOutput[i] = fmt.Sprintf("%s \t %s", account.Name, account.String())
-		}
-		termio.PrintStringResult(commandOutput...)
-	}
 }


### PR DESCRIPTION
fixes #281

Improved cli balance command.
Removed the detailed flag, display total balance, spendable(if its not equal to total balance), and other balance labels when they are not equal to zero.

single account
![image](https://user-images.githubusercontent.com/27733432/56168407-051c7500-5fd3-11e9-96ee-da77bee3bd25.png)

multiple accounts
![image](https://user-images.githubusercontent.com/27733432/56168442-1f565300-5fd3-11e9-8434-4f8cfab21a62.png)
