### PR TITLE
improved cli balance command

### DIFF
--- a/cli/commands/balance.go
+++ b/cli/commands/balance.go
@@ -20,7 +20,7 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 	}
 
 	var columns []string
-	var Account, Total, Spendable, Locked, Voting, Unconfirmed bool
+	var Account, Total, Spendable, Locked, Unconfirmed bool
 
 	checkAndAddColumn := func() {
 		if Account {
@@ -33,10 +33,7 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 			columns = append(columns, "Spendable")
 		}
 		if Locked {
-			columns = append(columns, "Locked By Tickets")
-		}
-		if Voting {
-			columns = append(columns, "Voting Authority")
+			columns = append(columns, "Locked")
 		}
 		if Unconfirmed {
 			columns = append(columns, "Unconfirmed")
@@ -58,10 +55,6 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 		if accounts[0].Balance.LockedByTickets != 0 {
 			Locked = true
 			rows[0] = append(rows[0], accounts[0].Balance.LockedByTickets)
-		}
-		if accounts[0].Balance.VotingAuthority != 0 {
-			Voting = true
-			rows[0] = append(rows[0], accounts[0].Balance.VotingAuthority)
 		}
 		if accounts[0].Balance.Unconfirmed != 0 {
 			Unconfirmed = true
@@ -91,10 +84,6 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 			if account.Balance.LockedByTickets != 0 {
 				Locked = true
 				rows[i] = append(rows[i], account.Balance.LockedByTickets)
-			}
-			if account.Balance.VotingAuthority != 0 {
-				Voting = true
-				rows[i] = append(rows[i], account.Balance.VotingAuthority)
 			}
 			if account.Balance.Unconfirmed != 0 {
 				Unconfirmed = true

--- a/cli/commands/balance.go
+++ b/cli/commands/balance.go
@@ -19,7 +19,7 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 		return err
 	}
 
-	var showAccount, showTotal, showSpendable, showUnconfirmed bool
+	var showAccount, showTotal, showSpendable, showLocked, showUnconfirmed bool
 
 	rows := make([][]interface{}, len(accounts))
 
@@ -31,11 +31,10 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 			rows[0] = append(rows[0], accounts[0].Balance.Total)
 		} else {
 			showTotal, showSpendable = true, true
-			rows[0] = append(rows[0], accounts[0].Balance.Total)
-			rows[0] = append(rows[0], accounts[0].Balance.Spendable)
+			rows[0] = append(rows[0], accounts[0].Balance.Total, accounts[0].Balance.Spendable)
 		}
 		if accounts[0].Balance.LockedByTickets != 0 {
-			showSpendable = true
+			showLocked = true
 			rows[0] = append(rows[0], accounts[0].Balance.LockedByTickets)
 		}
 		if accounts[0].Balance.Unconfirmed != 0 {
@@ -51,15 +50,13 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 			rows[i] = append(rows[i], account.Name)
 			if account.Balance.Total == account.Balance.Spendable {
 				showTotal = true
-
 				rows[i] = append(rows[i], account.Balance.Total)
 			} else {
 				showTotal, showSpendable = true, true
-				rows[i] = append(rows[i], account.Balance.Total)
-				rows[i] = append(rows[i], account.Balance.Spendable)
+				rows[i] = append(rows[i], accounts[i].Balance.Total, accounts[i].Balance.Spendable)
 			}
 			if account.Balance.LockedByTickets != 0 {
-				showSpendable = true
+				showLocked = true
 				rows[i] = append(rows[i], account.Balance.LockedByTickets)
 			}
 			if account.Balance.Unconfirmed != 0 {
@@ -79,7 +76,7 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 	if showSpendable {
 		columns = append(columns, "Spendable")
 	}
-	if showSpendable {
+	if showLocked {
 		columns = append(columns, "Locked")
 	}
 	if showUnconfirmed {

--- a/cli/commands/balance.go
+++ b/cli/commands/balance.go
@@ -20,62 +20,90 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 	}
 
 	var columns []string
+	var Account, Total, Spendable, Locked, Voting, Unconfirmed bool
+
+	checkAndAddColumn := func() {
+		if Account {
+			columns = append(columns, "Account")
+		}
+		if Total {
+			columns = append(columns, "Total")
+		}
+		if Spendable {
+			columns = append(columns, "Spendable")
+		}
+		if Locked {
+			columns = append(columns, "Locked By Tickets")
+		}
+		if Voting {
+			columns = append(columns, "Voting Authority")
+		}
+		if Unconfirmed {
+			columns = append(columns, "Unconfirmed")
+		}
+	}
 
 	if len(accounts) == 1 {
 		rows := make([][]interface{}, 1)
 		rows[0] = []interface{}{}
 
 		if accounts[0].Balance.Total == accounts[0].Balance.Spendable {
-			columns = append(columns, "Total")
+			Total = true
 			rows[0] = append(rows[0], accounts[0].Balance.Total)
 		} else {
-			columns = append(columns, "Total", "Spendable")
+			Total, Spendable = true, true
 			rows[0] = append(rows[0], accounts[0].Balance.Total)
 			rows[0] = append(rows[0], accounts[0].Balance.Spendable)
 		}
 		if accounts[0].Balance.LockedByTickets != 0 {
-			columns = append(columns, "Locked By Tickets")
+			Locked = true
 			rows[0] = append(rows[0], accounts[0].Balance.LockedByTickets)
 		}
 		if accounts[0].Balance.VotingAuthority != 0 {
-			columns = append(columns, "Voting Authority")
+			Voting = true
 			rows[0] = append(rows[0], accounts[0].Balance.VotingAuthority)
 		}
 		if accounts[0].Balance.Unconfirmed != 0 {
-			columns = append(columns, "Unconfirmed")
+			Unconfirmed = true
 			rows[0] = append(rows[0], accounts[0].Balance.Unconfirmed)
 		}
+
+		checkAndAddColumn()
 
 		termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
 	} else {
 		rows := make([][]interface{}, len(accounts))
+
 		for i, account := range accounts {
 			rows[i] = []interface{}{}
 
-			columns = append(columns, "Account")
+			Account = true
 			rows[i] = append(rows[i], account.Name)
 			if account.Balance.Total == account.Balance.Spendable {
-				columns = append(columns, "Total")
+				Total = true
+
 				rows[i] = append(rows[i], account.Balance.Total)
 			} else {
-				columns = append(columns, " Total", "Spendable")
+				Total, Spendable = true, true
 				rows[i] = append(rows[i], account.Balance.Total)
 				rows[i] = append(rows[i], account.Balance.Spendable)
 			}
 			if account.Balance.LockedByTickets != 0 {
-				columns = append(columns, "Locked By Tickets")
+				Locked = true
 				rows[i] = append(rows[i], account.Balance.LockedByTickets)
 			}
 			if account.Balance.VotingAuthority != 0 {
-				columns = append(columns, "Voting Authority")
+				Voting = true
 				rows[i] = append(rows[i], account.Balance.VotingAuthority)
 			}
 			if account.Balance.Unconfirmed != 0 {
-				columns = append(columns, "Unconfirmed")
+				Unconfirmed = true
 				rows[i] = append(rows[i], account.Balance.Unconfirmed)
 			}
 		}
-		
+
+		checkAndAddColumn()
+
 		termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
 	}
 

--- a/cli/commands/balance.go
+++ b/cli/commands/balance.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/raedahgroup/godcr/app/walletcore"
 	"github.com/raedahgroup/godcr/cli/termio"
@@ -11,7 +10,6 @@ import (
 // Balance displays the user's account balance.
 type BalanceCommand struct {
 	commanderStub
-	Detailed bool `short:"d" long:"detailed" description:"Display detailed account balance report"`
 }
 
 // Run runs the `balance` command, displaying the user's account balance.
@@ -21,47 +19,65 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 		return err
 	}
 
-	if balanceCommand.Detailed {
-		showDetailedBalance(accounts)
+	var columns []string
+
+	if len(accounts) == 1 {
+		rows := make([][]interface{}, 1)
+		rows[0] = []interface{}{}
+
+		if accounts[0].Balance.Total == accounts[0].Balance.Spendable {
+			columns = append(columns, "Total")
+			rows[0] = append(rows[0], accounts[0].Balance.Total)
+		} else {
+			columns = append(columns, "Total", "Spendable")
+			rows[0] = append(rows[0], accounts[0].Balance.Total)
+			rows[0] = append(rows[0], accounts[0].Balance.Spendable)
+		}
+		if accounts[0].Balance.LockedByTickets != 0 {
+			columns = append(columns, "Locked By Tickets")
+			rows[0] = append(rows[0], accounts[0].Balance.LockedByTickets)
+		}
+		if accounts[0].Balance.VotingAuthority != 0 {
+			columns = append(columns, "Voting Authority")
+			rows[0] = append(rows[0], accounts[0].Balance.VotingAuthority)
+		}
+		if accounts[0].Balance.Unconfirmed != 0 {
+			columns = append(columns, "Unconfirmed")
+			rows[0] = append(rows[0], accounts[0].Balance.Unconfirmed)
+		}
+
+		termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
 	} else {
-		showBalanceSummary(accounts)
+		rows := make([][]interface{}, len(accounts))
+		for i, account := range accounts {
+			rows[i] = []interface{}{}
+
+			columns = append(columns, "Account")
+			rows[i] = append(rows[i], account.Name)
+			if account.Balance.Total == account.Balance.Spendable {
+				columns = append(columns, "Total")
+				rows[i] = append(rows[i], account.Balance.Total)
+			} else {
+				columns = append(columns, " Total", "Spendable")
+				rows[i] = append(rows[i], account.Balance.Total)
+				rows[i] = append(rows[i], account.Balance.Spendable)
+			}
+			if account.Balance.LockedByTickets != 0 {
+				columns = append(columns, "Locked By Tickets")
+				rows[i] = append(rows[i], account.Balance.LockedByTickets)
+			}
+			if account.Balance.VotingAuthority != 0 {
+				columns = append(columns, "Voting Authority")
+				rows[i] = append(rows[i], account.Balance.VotingAuthority)
+			}
+			if account.Balance.Unconfirmed != 0 {
+				columns = append(columns, "Unconfirmed")
+				rows[i] = append(rows[i], account.Balance.Unconfirmed)
+			}
+		}
+		
+		termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
 	}
 
 	return nil
-}
-
-func showDetailedBalance(accountBalances []*walletcore.Account) {
-	columns := []string{
-		"Account",
-		"Total",
-		"Spendable",
-		"Locked By Tickets",
-		"Voting Authority",
-		"Unconfirmed",
-	}
-	rows := make([][]interface{}, len(accountBalances))
-	for i, account := range accountBalances {
-		rows[i] = []interface{}{
-			account.Name,
-			account.Balance.Total,
-			account.Balance.Spendable,
-			account.Balance.LockedByTickets,
-			account.Balance.VotingAuthority,
-			account.Balance.Unconfirmed,
-		}
-	}
-	termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
-}
-
-func showBalanceSummary(accounts []*walletcore.Account) {
-	if len(accounts) == 1 {
-		commandOutput := accounts[0].String()
-		termio.PrintStringResult(commandOutput)
-	} else {
-		commandOutput := make([]string, len(accounts))
-		for i, account := range accounts {
-			commandOutput[i] = fmt.Sprintf("%s \t %s", account.Name, account.String())
-		}
-		termio.PrintStringResult(commandOutput...)
-	}
 }

--- a/cli/commands/balance.go
+++ b/cli/commands/balance.go
@@ -19,82 +19,74 @@ func (balanceCommand BalanceCommand) Run(ctx context.Context, wallet walletcore.
 		return err
 	}
 
-	var columns []string
-	var Account, Total, Spendable, Locked, Unconfirmed bool
+	var showAccount, showTotal, showSpendable, showUnconfirmed bool
 
-	checkAndAddColumn := func() {
-		if Account {
-			columns = append(columns, "Account")
-		}
-		if Total {
-			columns = append(columns, "Total")
-		}
-		if Spendable {
-			columns = append(columns, "Spendable")
-		}
-		if Locked {
-			columns = append(columns, "Locked")
-		}
-		if Unconfirmed {
-			columns = append(columns, "Unconfirmed")
-		}
-	}
+	rows := make([][]interface{}, len(accounts))
 
 	if len(accounts) == 1 {
-		rows := make([][]interface{}, 1)
 		rows[0] = []interface{}{}
 
 		if accounts[0].Balance.Total == accounts[0].Balance.Spendable {
-			Total = true
+			showTotal = true
 			rows[0] = append(rows[0], accounts[0].Balance.Total)
 		} else {
-			Total, Spendable = true, true
+			showTotal, showSpendable = true, true
 			rows[0] = append(rows[0], accounts[0].Balance.Total)
 			rows[0] = append(rows[0], accounts[0].Balance.Spendable)
 		}
 		if accounts[0].Balance.LockedByTickets != 0 {
-			Locked = true
+			showSpendable = true
 			rows[0] = append(rows[0], accounts[0].Balance.LockedByTickets)
 		}
 		if accounts[0].Balance.Unconfirmed != 0 {
-			Unconfirmed = true
+			showUnconfirmed = true
 			rows[0] = append(rows[0], accounts[0].Balance.Unconfirmed)
 		}
 
-		checkAndAddColumn()
-
-		termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
 	} else {
-		rows := make([][]interface{}, len(accounts))
-
 		for i, account := range accounts {
 			rows[i] = []interface{}{}
 
-			Account = true
+			showAccount = true
 			rows[i] = append(rows[i], account.Name)
 			if account.Balance.Total == account.Balance.Spendable {
-				Total = true
+				showTotal = true
 
 				rows[i] = append(rows[i], account.Balance.Total)
 			} else {
-				Total, Spendable = true, true
+				showTotal, showSpendable = true, true
 				rows[i] = append(rows[i], account.Balance.Total)
 				rows[i] = append(rows[i], account.Balance.Spendable)
 			}
 			if account.Balance.LockedByTickets != 0 {
-				Locked = true
+				showSpendable = true
 				rows[i] = append(rows[i], account.Balance.LockedByTickets)
 			}
 			if account.Balance.Unconfirmed != 0 {
-				Unconfirmed = true
+				showUnconfirmed = true
 				rows[i] = append(rows[i], account.Balance.Unconfirmed)
 			}
 		}
-
-		checkAndAddColumn()
-
-		termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
 	}
+
+	var columns []string
+	if showAccount {
+		columns = append(columns, "Account")
+	}
+	if showTotal {
+		columns = append(columns, "Total")
+	}
+	if showSpendable {
+		columns = append(columns, "Spendable")
+	}
+	if showSpendable {
+		columns = append(columns, "Locked")
+	}
+	if showUnconfirmed {
+		columns = append(columns, "Unconfirmed")
+	}
+
+	termio.PrintTabularResult(termio.StdoutWriter, columns, rows)
 
 	return nil
 }

--- a/cli/termio/writer.go
+++ b/cli/termio/writer.go
@@ -36,6 +36,11 @@ func PrintTabularResult(w *tabwriter.Writer, columnsHeaders []string, rows [][]i
 			rowStr += "%v \t "
 		}
 
+		// append empty values in columns without data to maintain tabbed formatting
+		for i := len(row); i < columnLength; i++ {
+			rowStr += " \t "
+		}
+
 		rowStr = strings.TrimSuffix(rowStr, "\t ")
 		fmt.Fprintln(w, fmt.Sprintf(rowStr, row...))
 	}


### PR DESCRIPTION
fixes #281

Improved cli balance command.
Removed the detailed flag, display total balance, spendable(if its not equal to total balance), and other balance labels when they are not equal to zero.

single account
![image](https://user-images.githubusercontent.com/27733432/56257915-bac7f080-60c5-11e9-9e16-d910b209ac33.png)
other labels/fields like locked, immature are not visible because they have 0 DCR as their field value.

multiple accounts
![image](https://user-images.githubusercontent.com/27733432/56396799-8c1e5700-6238-11e9-8630-32373d5fb866.png)


other labels/fields like locked, immature are not visible because they have 0 DCR as their field value.