### PR TITLE
CLI password issue on windows

### DIFF
--- a/cli/termio/terminalprompt/getinput.go
+++ b/cli/termio/terminalprompt/getinput.go
@@ -67,22 +67,22 @@ func getTextInput(prompt string) (string, error) {
 
 // getPasswordInput - Prompt for password.
 func getPasswordInput(prompt string) (string, error) {
-	psw, err := getPasswd(prompt, true, os.Stdin, os.Stdout)
+	psw, err := getPassword(prompt, true, os.Stdin, os.Stdout)
 	if err != nil {
 		return "", err
 	}
 	return string(psw), nil
 }
 
-// getPasswd returns the input read from terminal.
+// getPassword returns the input read from terminal.
 // If prompt is not empty, it will be output as a prompt to the user
 // If masked is true, typing will be matched by asterisks on the screen.
 // Otherwise, typing will echo nothing.
-func getPasswd(prompt string, masked bool, r FdReader, w io.Writer) ([]byte, error) {
+func getPassword(prompt string, masked bool, r FdReader, w io.Writer) ([]byte, error) {
 	var err error
-	var pass, bs, mask []byte
+	var pass, backspace, mask []byte
 	if masked {
-		bs = []byte("\b \b")
+		backspace = []byte("\b \b")
 		mask = []byte("*")
 	}
 
@@ -112,7 +112,7 @@ func getPasswd(prompt string, masked bool, r FdReader, w io.Writer) ([]byte, err
 		} else if v == 127 || v == 8 {
 			if l := len(pass); l > 0 {
 				pass = pass[:l-1]
-				fmt.Fprint(w, string(bs))
+				fmt.Fprint(w, string(backspace))
 			}
 		} else if v == 13 || v == 10 {
 			break

--- a/cli/termio/terminalprompt/getinput.go
+++ b/cli/termio/terminalprompt/getinput.go
@@ -7,14 +7,43 @@ package terminalprompt
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
-	"os/exec"
-	"os/signal"
 	"strings"
 
 	"github.com/raedahgroup/godcr/cli/termio"
+	"golang.org/x/crypto/ssh/terminal"
 )
+
+type FdReader interface {
+	io.Reader
+	Fd() uintptr
+}
+
+var getch = func(r io.Reader) (byte, error) {
+	buf := make([]byte, 1)
+	if n, err := r.Read(buf); n == 0 || err != nil {
+		if err != nil {
+			return 0, err
+		}
+		return 0, io.EOF
+	}
+	return buf[0], nil
+}
+
+var (
+	maxLength            = 512
+	ErrInterrupted       = errors.New("interrupted")
+	ErrMaxLengthExceeded = fmt.Errorf("maximum byte limit (%v) exceeded", maxLength)
+)
+
+
+
+type terminalState struct {
+	state *terminal.State
+}
 
 // getTextInput - Prompt for text input.
 func getTextInput(prompt string) (string, error) {
@@ -38,51 +67,83 @@ func getTextInput(prompt string) (string, error) {
 
 // getPasswordInput - Prompt for password.
 func getPasswordInput(prompt string) (string, error) {
-	fmt.Print(prompt)
-
-	// Catch a ^C interrupt.
-	// Make sure that we reset term echo before exiting.
-	signalChannel := make(chan os.Signal, 1)
-	signal.Notify(signalChannel, os.Interrupt)
-	go func() {
-		<-signalChannel
-		setTerminalEcho(true)
-	}()
-
-	// when this function returns (after reading password input), stop listening for interrupt requests on `signalChannel`
-	defer signal.Stop(signalChannel)
-
-	// disable terminal echo
-	setTerminalEcho(false)
-
-	// Echo is disabled, now grab the data.
-	reader := bufio.NewReader(os.Stdin)
-	text, err := reader.ReadString('\n')
-
-	// re-enable terminal echo
-	setTerminalEcho(true)
-
+	psw, err := getPasswd(prompt, true, os.Stdin, os.Stdout)
 	if err != nil {
 		return "", err
 	}
-
-	return strings.TrimRight(text, "\n"), nil
+	return string(psw), nil
 }
 
-func setTerminalEcho(on bool) error {
-	var sttyEchoArg string
-	if on {
-		fmt.Println()
-		sttyEchoArg = "echo"
-	} else {
-		sttyEchoArg = "-echo"
+// getPasswd returns the input read from terminal.
+// If prompt is not empty, it will be output as a prompt to the user
+// If masked is true, typing will be matched by asterisks on the screen.
+// Otherwise, typing will echo nothing.
+func getPasswd(prompt string, masked bool, r FdReader, w io.Writer) ([]byte, error) {
+	var err error
+	var pass, bs, mask []byte
+	if masked {
+		bs = []byte("\b \b")
+		mask = []byte("*")
 	}
 
-	cmd := exec.Command("stty", sttyEchoArg)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
-	cmd.Run()
+	if isTerminal(r.Fd()) {
+		if oldState, err := makeRaw(r.Fd()); err != nil {
+			return pass, err
+		} else {
+			defer func() {
+				restore(r.Fd(), oldState)
+				fmt.Fprintln(w)
+			}()
+		}
+	}
 
-	return cmd.Wait()
+	if prompt != "" {
+		fmt.Fprint(w, prompt)
+	}
+
+	// Track total bytes read, not just bytes in the password.  This ensures any
+	// errors that might flood the console with nil or -1 bytes infinitely are
+	// capped.
+	var counter int
+	for counter = 0; counter <= maxLength; counter++ {
+		if v, e := getch(r); e != nil {
+			err = e
+			break
+		} else if v == 127 || v == 8 {
+			if l := len(pass); l > 0 {
+				pass = pass[:l-1]
+				fmt.Fprint(w, string(bs))
+			}
+		} else if v == 13 || v == 10 {
+			break
+		} else if v == 3 {
+			err = ErrInterrupted
+			break
+		} else if v != 0 {
+			pass = append(pass, v)
+			fmt.Fprint(w, string(mask))
+		}
+	}
+
+	if counter > maxLength {
+		err = ErrMaxLengthExceeded
+	}
+
+	return pass, err
+}
+
+func restore(fd uintptr, oldState *terminalState) error {
+	return terminal.Restore(int(fd), oldState.state)
+}
+
+func isTerminal(fd uintptr) bool {
+	return terminal.IsTerminal(int(fd))
+}
+
+func makeRaw(fd uintptr) (*terminalState, error) {
+	state, err := terminal.MakeRaw(int(fd))
+
+	return &terminalState{
+		state: state,
+	}, err
 }

--- a/cli/termio/terminalprompt/getinput.go
+++ b/cli/termio/terminalprompt/getinput.go
@@ -80,7 +80,7 @@ func getPasswordInput(prompt string) (string, error) {
 // Otherwise, typing will echo nothing.
 func getPassword(prompt string, masked bool, r FdReader, w io.Writer) ([]byte, error) {
 	var err error
-	var pass, backspace, mask []byte
+	var password, backspace, mask []byte
 	if masked {
 		backspace = []byte("\b \b")
 		mask = []byte("*")
@@ -88,7 +88,7 @@ func getPassword(prompt string, masked bool, r FdReader, w io.Writer) ([]byte, e
 
 	if isTerminal(r.Fd()) {
 		if oldState, err := makeRaw(r.Fd()); err != nil {
-			return pass, err
+			return password, err
 		} else {
 			defer func() {
 				restore(r.Fd(), oldState)
@@ -110,8 +110,8 @@ func getPassword(prompt string, masked bool, r FdReader, w io.Writer) ([]byte, e
 			err = e
 			break
 		} else if v == 127 || v == 8 {
-			if l := len(pass); l > 0 {
-				pass = pass[:l-1]
+			if l := len(password); l > 0 {
+				password = password[:l-1]
 				fmt.Fprint(w, string(backspace))
 			}
 		} else if v == 13 || v == 10 {
@@ -120,7 +120,7 @@ func getPassword(prompt string, masked bool, r FdReader, w io.Writer) ([]byte, e
 			err = ErrInterrupted
 			break
 		} else if v != 0 {
-			pass = append(pass, v)
+			password = append(password, v)
 			fmt.Fprint(w, string(mask))
 		}
 	}
@@ -129,7 +129,7 @@ func getPassword(prompt string, masked bool, r FdReader, w io.Writer) ([]byte, e
 		err = ErrMaxLengthExceeded
 	}
 
-	return pass, err
+	return password, err
 }
 
 func restore(fd uintptr, oldState *terminalState) error {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/rivo/tview v0.0.0-20190113120821-e5e361b9d790
 	github.com/skip2/go-qrcode v0.0.0-20190110000554-dc11ecdae0a9
 	github.com/srwiley/oksvg v0.0.0-20190414003808-c520f0a6c5cc // indirect
+	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9
 	golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f
 	google.golang.org/appengine v1.5.0 // indirect
 	google.golang.org/grpc v1.14.0


### PR DESCRIPTION
Fixes #92 and #292 
Resolved the issue of password showing as plaintext on windows and also reporting as invalid even when a valid password is used.
The error is due to the way the password was retrieved from the terminal.
This PR mask every entry from the user with as asterisk and retrieves the password without any extra byte

![image](https://user-images.githubusercontent.com/11990092/56324864-0b902580-6168-11e9-951a-7b35f8b7279c.png)

![image](https://user-images.githubusercontent.com/11990092/56325181-244d0b00-6169-11e9-86ce-838809101ff5.png)
