### PR TITLE
recent activities limit and balance modification on overview page

### DIFF
--- a/app/utils/utils.go
+++ b/app/utils/utils.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+func DecimalPortion(n float64) string {
+	decimalPlaces := fmt.Sprintf("%f", n-math.Floor(n)) // produces 0.xxxx0000
+	decimalPlaces = strings.Replace(decimalPlaces, "0.", "", -1) // remove 0.
+	decimalPlaces = strings.TrimRight(decimalPlaces, "0") // remove trailing 0s
+	return decimalPlaces
+}

--- a/app/walletcore/helper.go
+++ b/app/walletcore/helper.go
@@ -9,15 +9,6 @@ import (
 	"github.com/raedahgroup/dcrlibwallet/txhelper"
 )
 
-type SyncStatus uint8
-
-const (
-	SyncStatusNotStarted SyncStatus = iota
-	SyncStatusSuccess
-	SyncStatusError
-	SyncStatusInProgress
-)
-
 const (
 	// standard decred min confirmations is 2, this should be used as default for wallet operations
 	DefaultRequiredConfirmations = 2

--- a/terminal/pages/helpers.go
+++ b/terminal/pages/helpers.go
@@ -3,22 +3,15 @@ package pages
 import (
 	"fmt"
 	"math"
-	"strings"
 
 	"github.com/decred/dcrd/dcrutil"
+	"github.com/raedahgroup/godcr/app/utils"
 )
-
-func decimalPlaces(n float64) string {
-	decimalPlaces := fmt.Sprintf("%f", n-math.Floor(n))
-	decimalPlaces = strings.Replace(decimalPlaces, "0", "", -1)
-	decimalPlaces = strings.Replace(decimalPlaces, ".", "", -1)
-	return decimalPlaces
-}
 
 func maxDecimalPlaces(amounts []int64) (maxDecimalPlaces int) {
 	for _, amount := range amounts {
-		decimalPlaces := decimalPlaces(dcrutil.Amount(amount).ToCoin())
-		nDecimalPlaces := len(decimalPlaces)
+		decimalPortion := utils.DecimalPortion(dcrutil.Amount(amount).ToCoin())
+		nDecimalPlaces := len(decimalPortion)
 		if nDecimalPlaces > maxDecimalPlaces {
 			maxDecimalPlaces = nDecimalPlaces
 		}
@@ -29,11 +22,11 @@ func maxDecimalPlaces(amounts []int64) (maxDecimalPlaces int) {
 func formatAmountDisplay(amount int64, maxDecimalPlaces int) string {
 	dcrAmount := dcrutil.Amount(amount).ToCoin()
 	wholeNumber := int(math.Floor(dcrAmount))
-	decimalPlaces := decimalPlaces(dcrAmount)
+	decimalPortion := utils.DecimalPortion(dcrAmount)
 
-	if len(decimalPlaces) == 0 {
-		return fmt.Sprintf("%d%-*s DCR", wholeNumber, maxDecimalPlaces+1, decimalPlaces)
+	if len(decimalPortion) == 0 {
+		return fmt.Sprintf("%d%-*s DCR", wholeNumber, maxDecimalPlaces+1, decimalPortion)
 	} else {
-		return fmt.Sprintf("%d.%-*s DCR", wholeNumber, maxDecimalPlaces, decimalPlaces)
+		return fmt.Sprintf("%d.%-*s DCR", wholeNumber, maxDecimalPlaces, decimalPortion)
 	}
 }

--- a/web/routes/handlers.go
+++ b/web/routes/handlers.go
@@ -63,6 +63,11 @@ func (routes *Routes) overviewPage(res http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		data["loadTransactionErr"] = fmt.Sprintf("Error fetching recent activity: %s", err.Error())
 	}
+
+	// make sure the transactions are not more than 5
+	if len(txns) > 5 {
+		txns = txns[0:5]
+	}
 	data["transactions"] = txns
 
 	routes.renderPage("overview.html", data, res)

--- a/web/routes/handlers.go
+++ b/web/routes/handlers.go
@@ -52,11 +52,9 @@ func (routes *Routes) overviewPage(res http.ResponseWriter, req *http.Request) {
 	}
 
 	req.ParseForm()
-	showDetails := req.FormValue("detailed") != ""
 
 	data := map[string]interface{}{
 		"accounts": accounts,
-		"detailed": showDetails,
 	}
 
 	txns, _, err := routes.walletMiddleware.TransactionHistory(routes.ctx, -1, 5)

--- a/web/routes/templates.go
+++ b/web/routes/templates.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"fmt"
 	"html/template"
+	"strings"
 	"time"
 
 	"github.com/decred/dcrd/dcrutil"
@@ -42,12 +43,31 @@ func templateFuncMap() template.FuncMap {
 		"spendableBalance": func(balance *walletcore.Balance) string {
 			return walletcore.NormalizeBalance(balance.Spendable.ToCoin())
 		},
-		"totalBalance": func(accounts []*walletcore.Account) string {
+		"totalBalanceWholePart": func(accounts []*walletcore.Account) string {
 			var totalBalance walletcore.Balance
 			for _, account := range accounts {
 				totalBalance.Total += account.Balance.Total
 			}
-			return walletcore.NormalizeBalance(totalBalance.Total.ToCoin())
+			balanceStr := fmt.Sprintf("%010.8f", totalBalance.Total.ToCoin())
+			return strings.Split(balanceStr, ".")[0]
+		},
+		"totalBalance1st2Decimal": func(accounts []*walletcore.Account) string {
+			var totalBalance walletcore.Balance
+			for _, account := range accounts {
+				totalBalance.Total += account.Balance.Total
+			}
+			balanceStr := fmt.Sprintf("%010.8f", totalBalance.Total.ToCoin())
+			decimalPart := strings.Split(balanceStr, ".")[1]
+			return decimalPart[0:2]
+		},
+		"totalBalanceLast6Decimal": func(accounts []*walletcore.Account) string {
+			var totalBalance walletcore.Balance
+			for _, account := range accounts {
+				totalBalance.Total += account.Balance.Total
+			}
+			balanceStr := fmt.Sprintf("%010.8f", totalBalance.Total.ToCoin())
+			decimalPart := strings.Split(balanceStr, ".")[1]
+			return decimalPart[2:]
 		},
 		"intSum": func(numbers ...int) (sum int) {
 			for _, n := range numbers {

--- a/web/routes/templates.go
+++ b/web/routes/templates.go
@@ -43,18 +43,20 @@ func templateFuncMap() template.FuncMap {
 		"spendableBalance": func(balance *walletcore.Balance) string {
 			return walletcore.NormalizeBalance(balance.Spendable.ToCoin())
 		},
-		"splitBalanceIntoParts": func(accounts []*walletcore.Account) []string {
+		"splitBalanceIntoParts": func(accounts []*walletcore.Account) (balanceParts []string) {
 			var totalBalance walletcore.Balance
 			for _, account := range accounts {
 				totalBalance.Total += account.Balance.Total
 			}
-			balanceStr := fmt.Sprintf("%010.8f", totalBalance.Total.ToCoin())
-			splitBalance := strings.Split(balanceStr, ".")
-			return []string{
-				splitBalance[0],
-				splitBalance[1][0:2],
-				splitBalance[1][2:],
+			splitBalance := strings.Split(totalBalance.Total.String(), ".")
+			balanceParts = append(balanceParts, splitBalance[0])
+			if len(splitBalance) > 1 {
+				balanceParts = append(balanceParts, splitBalance[1][0:2])
 			}
+			if len(splitBalance[1]) > 2 {
+				balanceParts = append(balanceParts, splitBalance[1][2:])
+			}
+			return
 		},
 		"intSum": func(numbers ...int) (sum int) {
 			for _, n := range numbers {

--- a/web/routes/templates.go
+++ b/web/routes/templates.go
@@ -49,11 +49,11 @@ func templateFuncMap() template.FuncMap {
 				totalBalance.Total += account.Balance.Total
 			}
 			balanceStr := fmt.Sprintf("%010.8f", totalBalance.Total.ToCoin())
-			spitedParts := strings.Split(balanceStr, ".")
+			splitBalance := strings.Split(balanceStr, ".")
 			return []string{
-				spitedParts[0],
-				spitedParts[1][0:2],
-				spitedParts[1][2:],
+				splitBalance[0],
+				splitBalance[1][0:2],
+				splitBalance[1][2:],
 			}
 		},
 		"intSum": func(numbers ...int) (sum int) {

--- a/web/routes/templates.go
+++ b/web/routes/templates.go
@@ -3,10 +3,12 @@ package routes
 import (
 	"fmt"
 	"html/template"
-	"strings"
+	"math"
+	"strconv"
 	"time"
 
 	"github.com/decred/dcrd/dcrutil"
+	"github.com/raedahgroup/godcr/app/utils"
 	"github.com/raedahgroup/godcr/app/walletcore"
 )
 
@@ -43,30 +45,27 @@ func templateFuncMap() template.FuncMap {
 		"spendableBalance": func(balance *walletcore.Balance) string {
 			return walletcore.NormalizeBalance(balance.Spendable.ToCoin())
 		},
-		"splitBalanceIntoParts": func(accounts []*walletcore.Account) (balanceParts []string) {
-			var totalBalance walletcore.Balance
+		"splitBalanceIntoParts": func(accounts []*walletcore.Account) []string {
+			var totalBalance float64
 			for _, account := range accounts {
-				totalBalance.Total += account.Balance.Total
+				totalBalance += account.Balance.Total.ToCoin()
 			}
 
-			balanceParts = make([]string, 3)
+			balanceParts := make([]string, 3)
+			wholeNumber := int(math.Floor(totalBalance))
+			balanceParts[0] = strconv.Itoa(wholeNumber)
 
-			totalBalanceStr := totalBalance.Total.String()
-			if !strings.Contains(totalBalanceStr, ".") {
-				splitBalance := strings.Split(totalBalanceStr, " ")
-				balanceParts[0] = splitBalance[0]
-				balanceParts[1] = ""
-				balanceParts[2] = splitBalance[1]
-				return
+			decimalPortion := utils.DecimalPortion(totalBalance)
+			if len(decimalPortion) == 0 {
+				balanceParts[0] += " DCR"
+			} else if len(decimalPortion) <= 2 {
+				balanceParts[1] = fmt.Sprintf(".%s DCR", decimalPortion)
+			} else {
+				balanceParts[1] = fmt.Sprintf(".%s", decimalPortion[0:2])
+				balanceParts[2] = fmt.Sprintf("%s DCR", decimalPortion[2:])
 			}
-			splitBalance := strings.Split(totalBalanceStr, ".")
-			balanceParts[0] = splitBalance[0]
-			balanceParts[1] = "." + splitBalance[1][0:2]
 
-			if len(splitBalance[1]) > 2 {
-				balanceParts[2] = splitBalance[1][2:]
-			}
-			return
+			return balanceParts
 		},
 		"intSum": func(numbers ...int) (sum int) {
 			for _, n := range numbers {

--- a/web/routes/templates.go
+++ b/web/routes/templates.go
@@ -42,6 +42,13 @@ func templateFuncMap() template.FuncMap {
 		"spendableBalance": func(balance *walletcore.Balance) string {
 			return walletcore.NormalizeBalance(balance.Spendable.ToCoin())
 		},
+		"totalBalance": func(accounts []*walletcore.Account) string {
+			var totalBalance walletcore.Balance
+			for _, account := range accounts {
+				totalBalance.Total += account.Balance.Total
+			}
+			return walletcore.NormalizeBalance(totalBalance.Total.ToCoin())
+		},
 		"intSum": func(numbers ...int) (sum int) {
 			for _, n := range numbers {
 				sum += n

--- a/web/routes/templates.go
+++ b/web/routes/templates.go
@@ -43,31 +43,18 @@ func templateFuncMap() template.FuncMap {
 		"spendableBalance": func(balance *walletcore.Balance) string {
 			return walletcore.NormalizeBalance(balance.Spendable.ToCoin())
 		},
-		"totalBalanceWholePart": func(accounts []*walletcore.Account) string {
+		"splitBalanceIntoParts": func(accounts []*walletcore.Account) []string {
 			var totalBalance walletcore.Balance
 			for _, account := range accounts {
 				totalBalance.Total += account.Balance.Total
 			}
 			balanceStr := fmt.Sprintf("%010.8f", totalBalance.Total.ToCoin())
-			return strings.Split(balanceStr, ".")[0]
-		},
-		"totalBalance1st2Decimal": func(accounts []*walletcore.Account) string {
-			var totalBalance walletcore.Balance
-			for _, account := range accounts {
-				totalBalance.Total += account.Balance.Total
+			spitedParts := strings.Split(balanceStr, ".")
+			return []string{
+				spitedParts[0],
+				spitedParts[1][0:2],
+				spitedParts[1][2:],
 			}
-			balanceStr := fmt.Sprintf("%010.8f", totalBalance.Total.ToCoin())
-			decimalPart := strings.Split(balanceStr, ".")[1]
-			return decimalPart[0:2]
-		},
-		"totalBalanceLast6Decimal": func(accounts []*walletcore.Account) string {
-			var totalBalance walletcore.Balance
-			for _, account := range accounts {
-				totalBalance.Total += account.Balance.Total
-			}
-			balanceStr := fmt.Sprintf("%010.8f", totalBalance.Total.ToCoin())
-			decimalPart := strings.Split(balanceStr, ".")[1]
-			return decimalPart[2:]
 		},
 		"intSum": func(numbers ...int) (sum int) {
 			for _, n := range numbers {

--- a/web/routes/templates.go
+++ b/web/routes/templates.go
@@ -48,13 +48,23 @@ func templateFuncMap() template.FuncMap {
 			for _, account := range accounts {
 				totalBalance.Total += account.Balance.Total
 			}
-			splitBalance := strings.Split(totalBalance.Total.String(), ".")
-			balanceParts = append(balanceParts, splitBalance[0])
-			if len(splitBalance) > 1 {
-				balanceParts = append(balanceParts, splitBalance[1][0:2])
+
+			balanceParts = make([]string, 3)
+
+			totalBalanceStr := totalBalance.Total.String()
+			if !strings.Contains(totalBalanceStr, ".") {
+				splitBalance := strings.Split(totalBalanceStr, " ")
+				balanceParts[0] = splitBalance[0]
+				balanceParts[1] = ""
+				balanceParts[2] = splitBalance[1]
+				return
 			}
+			splitBalance := strings.Split(totalBalanceStr, ".")
+			balanceParts[0] = splitBalance[0]
+			balanceParts[1] = "." + splitBalance[1][0:2]
+
 			if len(splitBalance[1]) > 2 {
-				balanceParts = append(balanceParts, splitBalance[1][2:])
+				balanceParts[2] = splitBalance[1][2:]
 			}
 			return
 		},

--- a/web/static/app/src/css/style.scss
+++ b/web/static/app/src/css/style.scss
@@ -190,12 +190,6 @@ select#source-account[disabled] {
   opacity: 1;
 }
 
-.balance-table {
-  border: none;
-  width: 250px;
-  font-size: 16px;
-}
-
 .table.sticky-table {
   position: sticky;
   top: 0;

--- a/web/views/overview.html
+++ b/web/views/overview.html
@@ -11,13 +11,14 @@
                     <div class="row">
                         <div class="col-md-3 col-sm-6">
                             <p style="font-size: 15px">
-                                <b>{{ totalBalance .accounts }}</b><br/>
+                                <b>{{ totalBalanceWholePart .accounts }}.{{ totalBalance1st2Decimal .accounts }}<span
+                                            style="font-size:13px;">{{ totalBalanceLast6Decimal .accounts }}</span> DCR</b><br/>
                                 Current Total Balance
                             </p>
                         </div>
                     </div>
 
-                    <h4 class="mt-3">Recent Activities</h4>
+                    <h4 class="mt-3">Recent Activity</h4>
                     {{ if .loadTransactionErr }}
                     <div class="alert-danger"><p>{{.loadTransactionErr}}</p></div>
                     {{ else if eq (len .transactions) 0 }}

--- a/web/views/overview.html
+++ b/web/views/overview.html
@@ -12,9 +12,8 @@
                         <div class="col-md-3 col-sm-6">
                             <p style="font-size: 15px">
                                 {{ $balanceParts := splitBalanceIntoParts .accounts }}
-                                <b>{{ index $balanceParts 0 }}{{ if (ge (len $balanceParts) 1)}}.{{ index $balanceParts 1 }}{{ end }}<span
-                                            style="font-size:13px;">{{ if (ge (len $balanceParts) 1)}}{{ index $balanceParts 2 }}{{ end }}
-                                    </span></b><br/>
+                                <b>{{ index $balanceParts 0 }}{{ index $balanceParts 1 }}<span
+                                            style="font-size:13px;">{{ index $balanceParts 2 }}</span></b><br/>
                                 Current Total Balance
                             </p>
                         </div>

--- a/web/views/overview.html
+++ b/web/views/overview.html
@@ -12,8 +12,9 @@
                         <div class="col-md-3 col-sm-6">
                             <p style="font-size: 15px">
                                 {{ $balanceParts := splitBalanceIntoParts .accounts }}
-                                <b>{{ index $balanceParts 0 }}.{{ index $balanceParts 1 }}<span
-                                            style="font-size:13px;">{{ index $balanceParts 2 }}</span> DCR</b><br/>
+                                <b>{{ index $balanceParts 0 }}{{ if (ge (len $balanceParts) 1)}}.{{ index $balanceParts 1 }}{{ end }}<span
+                                            style="font-size:13px;">{{ if (ge (len $balanceParts) 1)}}{{ index $balanceParts 2 }}{{ end }}
+                                    </span></b><br/>
                                 Current Total Balance
                             </p>
                         </div>

--- a/web/views/overview.html
+++ b/web/views/overview.html
@@ -8,65 +8,16 @@
             <div class="container">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">
-                            Balance
-                            {{ if .detailed }}
-                            <small><a href="/">(Hide details)</a></small>
-                            {{ else }}
-                            <small><a href="/?detailed=yes">(Show details)</a></small>
-                            {{end}}
-                        </h5>
-                    <!-- if just one account and not detailed, show simple balance -->
-                {{ if and (not .detailed) (eq (len .accounts) 1) }}
-                {{ $account := index .accounts 0 }}
                     <div class="row">
                         <div class="col-md-3 col-sm-6">
-                            <table class="balance-table">
-                                <tr>
-                                    <td><b>Total:</b></td>
-                                    <td style="text-align: right;">{{ simpleBalance $account.Balance true }}</td>
-                                </tr>
-                            {{ if ne $account.Balance.Total $account.Balance.Spendable }}
-                                <tr>
-                                    <td><b>Spendable:</b></td>
-                                    <td style="text-align: right;">{{ spendableBalance $account.Balance }}</td>
-                                </tr>
-                            {{ end }}
-                            </table>
+                            <p style="font-size: 15px">
+                                <b>{{ totalBalance .accounts }}</b><br/>
+                                Current Total Balance
+                            </p>
                         </div>
                     </div>
-                {{ else }}
-                    <table class="table">
-                        <thead>
-                        <tr>
-                            <th>Account Name</th>
-                            <th>Balance</th>
-                        {{ if .detailed }}
-                            <th>Spendable</th>
-                            <th>Locked By Tickets</th>
-                            <th>Voting Authority</th>
-                            <th>Unconfirmed</th>
-                        {{ end }}
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {{ range $account := .accounts }}
-                        <tr>
-                            <td>{{ $account.Name }}</td>
-                            <td>{{ simpleBalance $account.Balance $.detailed }}</td>
-                        {{ if $.detailed }}
-                            <td> {{ $account.Balance.Spendable }}</td>
-                            <td> {{ $account.Balance.LockedByTickets }}</td>
-                            <td> {{ $account.Balance.VotingAuthority }}</td>
-                            <td> {{ $account.Balance.Unconfirmed }}</td>
-                        {{ end }}
-                        </tr>
-                        {{ end }}
-                        </tbody>
-                    </table>
-                {{ end }}
 
-                    <h4 class="mt-5">Recent Activities</h4>
+                    <h4 class="mt-3">Recent Activities</h4>
                     {{ if .loadTransactionErr }}
                     <div class="alert-danger"><p>{{.loadTransactionErr}}</p></div>
                     {{ else if eq (len .transactions) 0 }}

--- a/web/views/overview.html
+++ b/web/views/overview.html
@@ -11,8 +11,9 @@
                     <div class="row">
                         <div class="col-md-3 col-sm-6">
                             <p style="font-size: 15px">
-                                <b>{{ totalBalanceWholePart .accounts }}.{{ totalBalance1st2Decimal .accounts }}<span
-                                            style="font-size:13px;">{{ totalBalanceLast6Decimal .accounts }}</span> DCR</b><br/>
+                                {{ $balanceParts := splitBalanceIntoParts .accounts }}
+                                <b>{{ index $balanceParts 0 }}.{{ index $balanceParts 1 }}<span
+                                            style="font-size:13px;">{{ index $balanceParts 2 }}</span> DCR</b><br/>
                                 Current Total Balance
                             </p>
                         </div>


### PR DESCRIPTION
Resolves #300 and Resolves #301 by showing a maximum of 5 transactions under recent activities. The details link on the page is taken out and the total balance is shown directly to the user

![image](https://user-images.githubusercontent.com/11990092/56389908-a77e6780-6222-11e9-97dd-cdc750b958ac.png)
