### PR TITLE
ask to launch browser without blocking web server processes

### DIFF
--- a/web/server.go
+++ b/web/server.go
@@ -117,15 +117,17 @@ func askToLaunchBrowser(address string) {
 		return
 	}
 
-	if launchBrowserConfirmed {
-		fmt.Print("Launching browser... ") // use print so next text can be added to same line
+	if !launchBrowserConfirmed {
+		return
+	}
 
-		if launchError := launchBrowser("http://" + address); launchError != nil {
-			weblog.Log.Error("Failed to launch browser", launchError.Error())
-			fmt.Println("Browser failed to launch.")
-		} else {
-			fmt.Println("Done.")
-		}
+	fmt.Print("Launching browser... ") // use print so next text can be added to same line
+
+	if launchError := launchBrowser("http://" + address); launchError != nil {
+		weblog.Log.Error("Failed to launch browser", launchError.Error())
+		fmt.Println("Browser failed to launch.")
+	} else {
+		fmt.Println("Done.")
 	}
 }
 

--- a/web/server.go
+++ b/web/server.go
@@ -122,12 +122,11 @@ func askToLaunchBrowser(address string) {
 
 		if launchError := launchBrowser("http://" + address); launchError != nil {
 			weblog.Log.Error("Failed to launch browser", launchError.Error())
-			fmt.Println("Browser failed to launch")
-			return
+			fmt.Println("Browser failed to launch.")
+		} else {
+			fmt.Println("Done.")
 		}
 	}
-
-	fmt.Println("Ready")
 }
 
 func launchBrowser(url string) error {


### PR DESCRIPTION
After web server is started, user is asked to confirm whether or not to launch the browser with the godcr http server url. This PR ensures that the blockchain sync process done after the server is launched does not wait until the user responds to the prompt.

```
Starting web server
Web server running on 127.0.0.1:7778
Do you want to launch the web browser? (y/n): n
Ready
```

```Starting web server
Web server running on 127.0.0.1:7778
Do you want to launch the web browser? (y/n): y
Launching browser... Ready
```