### PR TITLE
Terminal navigation, history table column padding and fixed width fix.

### DIFF
--- a/app/walletcore/helper.go
+++ b/app/walletcore/helper.go
@@ -23,7 +23,7 @@ const (
 	DefaultRequiredConfirmations = 2
 
 	// minimum number of transactions to return per call to Wallet.TransactionHistory()
-	TransactionHistoryCountPerPage = 20
+	TransactionHistoryCountPerPage = 25
 
 	ConfirmedStatus = "Confirmed"
 

--- a/terminal/pages/accounts.go
+++ b/terminal/pages/accounts.go
@@ -1,0 +1,28 @@
+package pages
+
+import (
+	"github.com/gdamore/tcell"
+	"github.com/raedahgroup/godcr/terminal/primitives"
+	"github.com/rivo/tview"
+		"github.com/raedahgroup/godcr/terminal/helpers"
+)
+
+func accountsPage(setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
+	body := tview.NewFlex().SetDirection(tview.FlexRow)
+
+	body.AddItem(primitives.NewLeftAlignedTextView("Accounts"), 2, 1, false)
+
+	body.AddItem(primitives.NewLeftAlignedTextView("Accounts page coming soon").SetTextColor(helpers.DecredGreenColor), 0, 1, false)
+	
+	body.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEscape {
+			clearFocus()
+			return nil
+		}
+
+		return event
+	})
+
+	setFocus(body)
+	return body
+}

--- a/terminal/pages/accounts.go
+++ b/terminal/pages/accounts.go
@@ -2,9 +2,9 @@ package pages
 
 import (
 	"github.com/gdamore/tcell"
+	"github.com/raedahgroup/godcr/terminal/helpers"
 	"github.com/raedahgroup/godcr/terminal/primitives"
 	"github.com/rivo/tview"
-		"github.com/raedahgroup/godcr/terminal/helpers"
 )
 
 func accountsPage(setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
@@ -13,7 +13,7 @@ func accountsPage(setFocus func(p tview.Primitive) *tview.Application, clearFocu
 	body.AddItem(primitives.NewLeftAlignedTextView("Accounts"), 2, 1, false)
 
 	body.AddItem(primitives.NewLeftAlignedTextView("Accounts page coming soon").SetTextColor(helpers.DecredGreenColor), 0, 1, false)
-	
+
 	body.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEscape {
 			clearFocus()

--- a/terminal/pages/exit.go
+++ b/terminal/pages/exit.go
@@ -1,8 +1,11 @@
 package pages
 
-import "github.com/rivo/tview"
+import (
+	"github.com/raedahgroup/godcr/app"
+	"github.com/rivo/tview"
+)
 
-func exitPage(tviewApp *tview.Application, setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
+func exitPage(walletMiddleware app.WalletMiddleware, tviewApp *tview.Application, setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
 	body := tview.NewModal().
 		SetText("Do you want to quit Terminal application?").
 		AddButtons([]string{"Quit", "Cancel"}).
@@ -10,10 +13,10 @@ func exitPage(tviewApp *tview.Application, setFocus func(p tview.Primitive) *tvi
 			if buttonLabel == "Quit" {
 				tviewApp.Stop()
 			} else {
-				clearFocus()
+				tviewApp.SetRoot(rootPage(tviewApp, walletMiddleware), true)
 			}
 		})
 
-	setFocus(body)
+	tviewApp.SetRoot(body, true)
 	return body
 }

--- a/terminal/pages/exit.go
+++ b/terminal/pages/exit.go
@@ -1,0 +1,21 @@
+package pages
+
+import (
+	"github.com/rivo/tview"
+)
+
+func exitPage(tviewApp *tview.Application, setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
+	body := tview.NewModal().
+		SetText("Do you want to quit Terminal application?").
+		AddButtons([]string{"Quit", "Cancel"}).
+		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+			if buttonLabel == "Quit" {
+				tviewApp.Stop()
+			} else {
+				clearFocus()
+			}
+		})
+
+	setFocus(body)
+	return body
+}

--- a/terminal/pages/exit.go
+++ b/terminal/pages/exit.go
@@ -1,8 +1,6 @@
 package pages
 
-import (
-	"github.com/rivo/tview"
-)
+import "github.com/rivo/tview"
 
 func exitPage(tviewApp *tview.Application, setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
 	body := tview.NewModal().

--- a/terminal/pages/history.go
+++ b/terminal/pages/history.go
@@ -34,7 +34,7 @@ func historyPage(wallet walletcore.Wallet, hintTextView *primitives.TextView, tv
 		body.RemoveItem(transactionDetailsTable)
 
 		titleTextView.SetText("History")
-		hintTextView.SetText("TIP: Use ARROW UP/DOWN to select txn, ENTER to view details, ESC to return to navigation menu")
+		hintTextView.SetText("TIP: Use ARROW UP/DOWN to select txn,\nENTER to view details, ESC to return to navigation menu")
 
 		body.AddItem(historyTable, 0, 1, true)
 		tviewApp.SetFocus(historyTable)
@@ -68,7 +68,7 @@ func historyPage(wallet walletcore.Wallet, hintTextView *primitives.TextView, tv
 		txHash := displayedTxHashes[row-1]
 
 		titleTextView.SetText("Transaction Details")
-		hintTextView.SetText("TIP: Use ARROW UP/DOWN to scroll, BACKSPACE to view History page, ESC to return to navigation menu")
+		hintTextView.SetText("TIP: Use ARROW UP/DOWN to scroll, \nBACKSPACE to view History page, ESC to return to navigation menu")
 
 		transactionDetailsTable.Clear()
 		body.AddItem(transactionDetailsTable, 0, 1, true)
@@ -89,22 +89,22 @@ func historyPage(wallet walletcore.Wallet, hintTextView *primitives.TextView, tv
 	})
 
 	tableHeaderCell := func(text string) *tview.TableCell {
-		return tview.NewTableCell(text).SetAlign(tview.AlignCenter).SetSelectable(false)
+		return tview.NewTableCell(text).SetAlign(tview.AlignCenter).SetSelectable(false).SetMaxWidth(1).SetExpansion(1)
 	}
 
 	// history table header
 	historyTable.SetCell(0, 0, tableHeaderCell("Date (UTC)"))
-	historyTable.SetCell(0, 1, tableHeaderCell("Direction"))
-	historyTable.SetCell(0, 2, tableHeaderCell("Amount"))
-	historyTable.SetCell(0, 3, tableHeaderCell("Status"))
-	historyTable.SetCell(0, 4, tableHeaderCell("Type"))
+	historyTable.SetCell(0, 1, tableHeaderCell(fmt.Sprintf("%10s", "Direction")))
+	historyTable.SetCell(0, 2, tableHeaderCell(fmt.Sprintf("%8s", "Amount")))
+	historyTable.SetCell(0, 3, tableHeaderCell(fmt.Sprintf("%5s", "Status")))
+	historyTable.SetCell(0, 4, tableHeaderCell(fmt.Sprintf("%-5s", "Type")))
 
 	displayHistoryTable()
 
 	// fetch tx to display in subroutine so the UI isn't blocked
 	go fetchAndDisplayTransactions(-1, wallet, historyTable, tviewApp, displayMessage)
 
-	hintTextView.SetText("TIP: Use ARROW UP/DOWN to select txn, ENTER to view details, ESC to return to navigation menu")
+	hintTextView.SetText("TIP: Use ARROW UP/DOWN to select txn, \nENTER to view details, ESC to return to navigation menu")
 
 	tviewApp.SetFocus(body)
 
@@ -140,11 +140,11 @@ func fetchAndDisplayTransactions(startBlockHeight int32, wallet walletcore.Walle
 		for _, tx := range txns {
 			nextRowIndex := historyTable.GetRowCount()
 
-			historyTable.SetCell(nextRowIndex, 0, tview.NewTableCell(tx.FormattedTime).SetAlign(tview.AlignCenter))
-			historyTable.SetCell(nextRowIndex, 1, tview.NewTableCell(tx.Direction.String()).SetAlign(tview.AlignCenter))
-			historyTable.SetCell(nextRowIndex, 2, tview.NewTableCell(formatAmount(tx.RawAmount)).SetAlign(tview.AlignRight))
-			historyTable.SetCell(nextRowIndex, 3, tview.NewTableCell(tx.Status).SetAlign(tview.AlignCenter))
-			historyTable.SetCell(nextRowIndex, 4, tview.NewTableCell(tx.Type).SetAlign(tview.AlignCenter))
+			historyTable.SetCell(nextRowIndex, 0, tview.NewTableCell(fmt.Sprintf("%-10s", tx.FormattedTime)).SetAlign(tview.AlignCenter).SetMaxWidth(1).SetExpansion(1).SetMaxWidth(1).SetExpansion(1))
+			historyTable.SetCell(nextRowIndex, 1, tview.NewTableCell(fmt.Sprintf("%-10s", tx.Direction.String())).SetAlign(tview.AlignCenter).SetMaxWidth(2).SetExpansion(1))
+			historyTable.SetCell(nextRowIndex, 2, tview.NewTableCell(fmt.Sprintf("%15s", formatAmount(tx.RawAmount))).SetAlign(tview.AlignCenter).SetMaxWidth(3).SetExpansion(1))
+			historyTable.SetCell(nextRowIndex, 3, tview.NewTableCell(fmt.Sprintf("%12s", tx.Status)).SetAlign(tview.AlignCenter).SetMaxWidth(1).SetExpansion(1))
+			historyTable.SetCell(nextRowIndex, 4, tview.NewTableCell(fmt.Sprintf("%-8s", tx.Type)).SetAlign(tview.AlignCenter).SetMaxWidth(1).SetExpansion(1))
 
 			displayedTxHashes = append(displayedTxHashes, tx.Hash)
 		}

--- a/terminal/pages/history.go
+++ b/terminal/pages/history.go
@@ -80,11 +80,7 @@ func historyPage(wallet walletcore.Wallet, hintTextView *primitives.TextView, tv
 
 	// handler for returning back to history table
 	transactionDetailsTable.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		if event.Key() == tcell.KeyEscape {
-			clearFocus()
-			return nil
-		}
-		if event.Key() == tcell.KeyBackspace || event.Key() == tcell.KeyBackspace2 {
+		if event.Key() == tcell.KeyEscape || event.Key() == tcell.KeyBackspace || event.Key() == tcell.KeyBackspace2 {
 			displayHistoryTable()
 			return nil
 		}

--- a/terminal/pages/overview.go
+++ b/terminal/pages/overview.go
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gdamore/tcell"
 	"github.com/raedahgroup/godcr/app/walletcore"
@@ -65,10 +66,10 @@ func renderRecentActivity(overviewPage *tview.Flex, wallet walletcore.Wallet, tv
 
 	// historyTable header
 	historyTable.SetHeaderCell(0, 0, "Date (UTC)")
-	historyTable.SetHeaderCell(0, 1, "Direction")
-	historyTable.SetHeaderCell(0, 2, "Amount")
-	historyTable.SetHeaderCell(0, 3, "Status")
-	historyTable.SetHeaderCell(0, 4, "Type")
+	historyTable.SetHeaderCell(0, 1, (fmt.Sprintf("%10s", "Direction")))
+	historyTable.SetHeaderCell(0, 2, (fmt.Sprintf("%8s", "Amount")))
+	historyTable.SetHeaderCell(0, 3, (fmt.Sprintf("%5s", "Status")))
+	historyTable.SetHeaderCell(0, 4, (fmt.Sprintf("%-5s", "Type")))
 
 	// calculate max number of digits after decimal point for all amounts for 5 most recent txs
 	inputsAndOutputsAmount := make([]int64, 5)
@@ -92,11 +93,11 @@ func renderRecentActivity(overviewPage *tview.Flex, wallet walletcore.Wallet, tv
 			break
 		}
 
-		historyTable.SetCell(nextRowIndex, 0, tview.NewTableCell(tx.FormattedTime).SetAlign(tview.AlignCenter))
-		historyTable.SetCell(nextRowIndex, 1, tview.NewTableCell(tx.Direction.String()).SetAlign(tview.AlignCenter))
-		historyTable.SetCell(nextRowIndex, 2, tview.NewTableCell(formatAmount(tx.RawAmount)).SetAlign(tview.AlignRight))
-		historyTable.SetCell(nextRowIndex, 3, tview.NewTableCell(tx.Status).SetAlign(tview.AlignCenter))
-		historyTable.SetCell(nextRowIndex, 4, tview.NewTableCell(tx.Type).SetAlign(tview.AlignCenter))
+			historyTable.SetCell(nextRowIndex, 0, tview.NewTableCell(fmt.Sprintf("%-10s", tx.FormattedTime)).SetAlign(tview.AlignCenter).SetMaxWidth(1).SetExpansion(1).SetMaxWidth(1).SetExpansion(1))
+			historyTable.SetCell(nextRowIndex, 1, tview.NewTableCell(fmt.Sprintf("%-10s", tx.Direction.String())).SetAlign(tview.AlignCenter).SetMaxWidth(2).SetExpansion(1))
+			historyTable.SetCell(nextRowIndex, 2, tview.NewTableCell(fmt.Sprintf("%15s", formatAmount(tx.RawAmount))).SetAlign(tview.AlignCenter).SetMaxWidth(3).SetExpansion(1))
+			historyTable.SetCell(nextRowIndex, 3, tview.NewTableCell(fmt.Sprintf("%12s", tx.Status)).SetAlign(tview.AlignCenter).SetMaxWidth(1).SetExpansion(1))
+			historyTable.SetCell(nextRowIndex, 4, tview.NewTableCell(fmt.Sprintf("%-8s", tx.Type)).SetAlign(tview.AlignCenter).SetMaxWidth(1).SetExpansion(1))
 	}
 
 	historyTable.SetDoneFunc(func(key tcell.Key) {

--- a/terminal/pages/rootpage.go
+++ b/terminal/pages/rootpage.go
@@ -71,7 +71,7 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 	})
 
 	menuColumn.AddItem("Exit", "", 0, func() {
-		tviewApp.Stop()
+		displayPage(exitPage(tviewApp, tviewApp.SetFocus, clearFocus))
 	})
 
 	netType := walletMiddleware.NetType()
@@ -86,6 +86,10 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 	gridLayout.AddItem(hintTextView, 4, 2, 1, 1, 0, 0, false)
 
 	menuColumn.SetCurrentItem(0)
+
+	menuColumn.SetDoneFunc(func() {
+		displayPage(exitPage(tviewApp, tviewApp.SetFocus, clearFocus))
+	})
 
 	displayPage(overviewPage(walletMiddleware, hintTextView, tviewApp, clearFocus))
 

--- a/terminal/pages/rootpage.go
+++ b/terminal/pages/rootpage.go
@@ -38,33 +38,39 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 		tviewApp.SetFocus(menuColumn)
 	}
 
-	menuColumn.AddItem("Overview", "", 'o', func() {
+	menuColumn.AddItem("Overview", "", 0, func() {
 		displayPage(overviewPage(walletMiddleware, hintTextView, tviewApp, clearFocus))
 	})
 
-	menuColumn.AddItem("History", "", 'h', func() {
+	menuColumn.AddItem("History", "", 0, func() {
 		displayPage(historyPage(walletMiddleware, hintTextView, tviewApp, clearFocus))
 	})
 
-	menuColumn.AddItem("Send", "", 's', func() {
+	menuColumn.AddItem("Send", "", 0, func() {
 		displayPage(sendPage(walletMiddleware, hintTextView, tviewApp.SetFocus, clearFocus))
 	})
 
-	menuColumn.AddItem("Receive", "", 'r', func() {
+	menuColumn.AddItem("Receive", "", 0, func() {
 		displayPage(receivePage(walletMiddleware, hintTextView, tviewApp.SetFocus, clearFocus))
 	})
 
-	menuColumn.AddItem("Staking", "", 'k', func() {
+	menuColumn.AddItem("Staking", "", 0, func() {
 		displayPage(stakingPage(walletMiddleware, hintTextView, tviewApp.SetFocus, clearFocus))
 	})
 
-	menuColumn.AddItem("Accounts", "", 'a', nil)
+	menuColumn.AddItem("Accounts", "", 0, func() {
+		displayPage(accountsPage(tviewApp.SetFocus, clearFocus))
+	})
 
-	menuColumn.AddItem("Security", "", 'c', nil)
+	menuColumn.AddItem("Security", "", 0, func() {
+		displayPage(securityPage(tviewApp.SetFocus, clearFocus))
+	})
 
-	menuColumn.AddItem("Settings", "", 't', nil)
+	menuColumn.AddItem("Settings", "", 0, func() {
+		displayPage(settingsPage(tviewApp.SetFocus, clearFocus))
+	})
 
-	menuColumn.AddItem("Exit", "", 'q', func() {
+	menuColumn.AddItem("Exit", "", 0, func() {
 		tviewApp.Stop()
 	})
 

--- a/terminal/pages/rootpage.go
+++ b/terminal/pages/rootpage.go
@@ -13,32 +13,44 @@ import (
 func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware) tview.Primitive {
 	gridLayout := tview.NewGrid().
 		SetRows(3, 1, 0, 1, 3).
-		SetColumns(25, 2, 0, 2).
-		SetBordersColor(helpers.DecredLightBlueColor)
+		SetColumns(20, 2, 0, 2)
+
+		// SetBordersColor(helpers.DecredLightBlueColor)
 
 	gridLayout.SetBackgroundColor(tcell.ColorBlack)
-	
+
 	menuColumn := primitives.NewList()
 
+	displayPageFlex := tview.NewFlex().SetDirection(tview.FlexRow)
+	displayPageFlex.SetBorderPadding(0, 0, 1, 1)
 	var activePage tview.Primitive
 
 	// displayPage sets the currently active page to be displayed on the second column of the grid layout
 	displayPage := func(page tview.Primitive) {
 		gridLayout.RemoveItem(activePage)
+		gridLayout.SetColumns(20, 2, 0, 2)
 		menuColumn.ShowShortcut(false)
 		menuColumn.SetMainTextColor(helpers.HintTextColor)
+		menuColumn.SetBorder(false)
+		menuColumn.SetBorderPadding(1, 0, 1, 0)
+		displayPageFlex.SetBorder(true).SetBorderColor(helpers.DecredLightBlueColor)
 		activePage = page
-		gridLayout.AddItem(activePage, 2, 2, 1, 1, 0, 0, true)
+		gridLayout.AddItem(displayPageFlex.AddItem(activePage, 0, 1, true), 1, 1, 2, 3, 0, 0, true)
 	}
 
 	hintTextView := primitives.WordWrappedTextView("")
 	hintTextView.SetTextColor(helpers.HintTextColor)
 
 	clearFocus := func() {
-		gridLayout.RemoveItem(activePage)
-		menuColumn.SetMainTextColor(tcell.ColorWhite)
 		hintTextView.SetText("")
+		// gridLayout.RemoveItem(activePage)
+		gridLayout.SetColumns(25, 2, 0, 2)
+		displayPageFlex.RemoveItem(activePage)
+		displayPageFlex.SetBorder(false)
 		tviewApp.Draw()
+		menuColumn.SetMainTextColor(tcell.ColorWhite)
+		menuColumn.SetBorderPadding(0, 0, 1, 0)
+		menuColumn.SetBorder(true).SetBorderColor(helpers.DecredLightBlueColor)
 		menuColumn.ShowShortcut(true)
 		tviewApp.SetFocus(menuColumn)
 	}
@@ -85,10 +97,9 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 	gridLayout.AddItem(header, 0, 0, 1, 4, 0, 0, false)
 
 	menuColumn.SetShortcutColor(helpers.DecredLightBlueColor)
-	menuColumn.SetBorder(true).SetBorderColor(helpers.DecredLightBlueColor)
 	gridLayout.AddItem(menuColumn, 1, 0, 4, 1, 0, 0, true)
 
-	gridLayout.AddItem(hintTextView, 4, 2, 1, 1, 0, 0, false)
+	gridLayout.AddItem(hintTextView, 4, 1, 1, 3, 0, 0, false)
 
 	menuColumn.SetCurrentItem(0)
 

--- a/terminal/pages/rootpage.go
+++ b/terminal/pages/rootpage.go
@@ -17,7 +17,7 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 		SetBordersColor(helpers.DecredLightBlueColor)
 
 	gridLayout.SetBackgroundColor(tcell.ColorBlack)
-
+	
 	menuColumn := primitives.NewList()
 
 	var activePage tview.Primitive
@@ -26,6 +26,7 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 	displayPage := func(page tview.Primitive) {
 		gridLayout.RemoveItem(activePage)
 		menuColumn.ShowShortcut(false)
+		menuColumn.SetMainTextColor(helpers.HintTextColor)
 		activePage = page
 		gridLayout.AddItem(activePage, 2, 2, 1, 1, 0, 0, true)
 	}
@@ -35,6 +36,7 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 
 	clearFocus := func() {
 		gridLayout.RemoveItem(activePage)
+		menuColumn.SetMainTextColor(tcell.ColorWhite)
 		hintTextView.SetText("")
 		tviewApp.Draw()
 		menuColumn.ShowShortcut(true)

--- a/terminal/pages/rootpage.go
+++ b/terminal/pages/rootpage.go
@@ -17,12 +17,15 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 		SetBordersColor(helpers.DecredLightBlueColor)
 
 	gridLayout.SetBackgroundColor(tcell.ColorBlack)
+	
+	menuColumn := primitives.NewList()
 
 	var activePage tview.Primitive
 
 	// displayPage sets the currently active page to be displayed on the second column of the grid layout
 	displayPage := func(page tview.Primitive) {
 		gridLayout.RemoveItem(activePage)
+		menuColumn.ShowShortcut(false)
 		activePage = page
 		gridLayout.AddItem(activePage, 2, 2, 1, 1, 0, 0, true)
 	}
@@ -30,47 +33,47 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 	hintTextView := primitives.WordWrappedTextView("")
 	hintTextView.SetTextColor(helpers.HintTextColor)
 
-	menuColumn := tview.NewList()
 	clearFocus := func() {
 		gridLayout.RemoveItem(activePage)
 		hintTextView.SetText("")
 		tviewApp.Draw()
+		menuColumn.ShowShortcut(true)
 		tviewApp.SetFocus(menuColumn)
 	}
 
-	menuColumn.AddItem("Overview", "", 0, func() {
+	menuColumn.AddItem("Overview", "", 'o', func() {
 		displayPage(overviewPage(walletMiddleware, hintTextView, tviewApp, clearFocus))
 	})
 
-	menuColumn.AddItem("History", "", 0, func() {
+	menuColumn.AddItem("History", "", 'h', func() {
 		displayPage(historyPage(walletMiddleware, hintTextView, tviewApp, clearFocus))
 	})
 
-	menuColumn.AddItem("Send", "", 0, func() {
+	menuColumn.AddItem("Send", "", 's', func() {
 		displayPage(sendPage(walletMiddleware, hintTextView, tviewApp.SetFocus, clearFocus))
 	})
 
-	menuColumn.AddItem("Receive", "", 0, func() {
+	menuColumn.AddItem("Receive", "", 'r', func() {
 		displayPage(receivePage(walletMiddleware, hintTextView, tviewApp.SetFocus, clearFocus))
 	})
 
-	menuColumn.AddItem("Staking", "", 0, func() {
+	menuColumn.AddItem("Staking", "", 'k', func() {
 		displayPage(stakingPage(walletMiddleware, hintTextView, tviewApp.SetFocus, clearFocus))
 	})
 
-	menuColumn.AddItem("Accounts", "", 0, func() {
+	menuColumn.AddItem("Accounts", "", 'a', func() {
 		displayPage(accountsPage(tviewApp.SetFocus, clearFocus))
 	})
 
-	menuColumn.AddItem("Security", "", 0, func() {
+	menuColumn.AddItem("Security", "", 'u', func() {
 		displayPage(securityPage(tviewApp.SetFocus, clearFocus))
 	})
 
-	menuColumn.AddItem("Settings", "", 0, func() {
+	menuColumn.AddItem("Settings", "", 't', func() {
 		displayPage(settingsPage(tviewApp.SetFocus, clearFocus))
 	})
 
-	menuColumn.AddItem("Exit", "", 0, func() {
+	menuColumn.AddItem("Exit", "", 'e', func() {
 		displayPage(exitPage(tviewApp, tviewApp.SetFocus, clearFocus))
 	})
 
@@ -90,7 +93,7 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 	menuColumn.SetDoneFunc(func() {
 		displayPage(exitPage(tviewApp, tviewApp.SetFocus, clearFocus))
 	})
-
+	
 	displayPage(overviewPage(walletMiddleware, hintTextView, tviewApp, clearFocus))
 
 	return gridLayout

--- a/terminal/pages/rootpage.go
+++ b/terminal/pages/rootpage.go
@@ -17,7 +17,7 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 		SetBordersColor(helpers.DecredLightBlueColor)
 
 	gridLayout.SetBackgroundColor(tcell.ColorBlack)
-	
+
 	menuColumn := primitives.NewList()
 
 	var activePage tview.Primitive
@@ -93,7 +93,7 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 	menuColumn.SetDoneFunc(func() {
 		displayPage(exitPage(tviewApp, tviewApp.SetFocus, clearFocus))
 	})
-	
+
 	displayPage(overviewPage(walletMiddleware, hintTextView, tviewApp, clearFocus))
 
 	return gridLayout

--- a/terminal/pages/rootpage.go
+++ b/terminal/pages/rootpage.go
@@ -15,8 +15,6 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 		SetRows(3, 1, 0, 1, 3).
 		SetColumns(20, 2, 0, 2)
 
-		// SetBordersColor(helpers.DecredLightBlueColor)
-
 	gridLayout.SetBackgroundColor(tcell.ColorBlack)
 
 	menuColumn := primitives.NewList()
@@ -43,7 +41,6 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 
 	clearFocus := func() {
 		hintTextView.SetText("")
-		// gridLayout.RemoveItem(activePage)
 		gridLayout.SetColumns(25, 2, 0, 2)
 		displayPageFlex.RemoveItem(activePage)
 		displayPageFlex.SetBorder(false)
@@ -88,7 +85,7 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 	})
 
 	menuColumn.AddItem("Exit", "", 'e', func() {
-		displayPage(exitPage(tviewApp, tviewApp.SetFocus, clearFocus))
+		displayPage(exitPage(walletMiddleware, tviewApp, tviewApp.SetFocus, clearFocus))
 	})
 
 	netType := walletMiddleware.NetType()
@@ -104,7 +101,7 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 	menuColumn.SetCurrentItem(0)
 
 	menuColumn.SetDoneFunc(func() {
-		displayPage(exitPage(tviewApp, tviewApp.SetFocus, clearFocus))
+		displayPage(exitPage(walletMiddleware, tviewApp, tviewApp.SetFocus, clearFocus))
 	})
 
 	displayPage(overviewPage(walletMiddleware, hintTextView, tviewApp, clearFocus))

--- a/terminal/pages/rootpage.go
+++ b/terminal/pages/rootpage.go
@@ -12,11 +12,10 @@ import (
 
 func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware) tview.Primitive {
 	gridLayout := tview.NewGrid().
-		SetRows(3, 1, 0, 1, 3).
+		SetRows(3, 1, 0, 1, 2).
 		SetColumns(20, 2, 0, 2)
 
 	gridLayout.SetBackgroundColor(tcell.ColorBlack)
-
 	menuColumn := primitives.NewList()
 
 	displayPageFlex := tview.NewFlex().SetDirection(tview.FlexRow)
@@ -33,7 +32,7 @@ func rootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 		menuColumn.SetBorderPadding(1, 0, 1, 0)
 		displayPageFlex.SetBorder(true).SetBorderColor(helpers.DecredLightBlueColor)
 		activePage = page
-		gridLayout.AddItem(displayPageFlex.AddItem(activePage, 0, 1, true), 1, 1, 2, 3, 0, 0, true)
+		gridLayout.AddItem(displayPageFlex.AddItem(activePage, 0, 1, true), 1, 1, 3, 3, 0, 0, true)
 	}
 
 	hintTextView := primitives.WordWrappedTextView("")

--- a/terminal/pages/security.go
+++ b/terminal/pages/security.go
@@ -2,9 +2,9 @@ package pages
 
 import (
 	"github.com/gdamore/tcell"
+	"github.com/raedahgroup/godcr/terminal/helpers"
 	"github.com/raedahgroup/godcr/terminal/primitives"
 	"github.com/rivo/tview"
-		"github.com/raedahgroup/godcr/terminal/helpers"
 )
 
 func securityPage(setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
@@ -13,7 +13,7 @@ func securityPage(setFocus func(p tview.Primitive) *tview.Application, clearFocu
 	body.AddItem(primitives.NewLeftAlignedTextView("Security"), 2, 1, false)
 
 	body.AddItem(primitives.NewLeftAlignedTextView("Security page coming soon").SetTextColor(helpers.DecredGreenColor), 0, 1, false)
-	
+
 	body.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEscape {
 			clearFocus()

--- a/terminal/pages/security.go
+++ b/terminal/pages/security.go
@@ -1,0 +1,28 @@
+package pages
+
+import (
+	"github.com/gdamore/tcell"
+	"github.com/raedahgroup/godcr/terminal/primitives"
+	"github.com/rivo/tview"
+		"github.com/raedahgroup/godcr/terminal/helpers"
+)
+
+func securityPage(setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
+	body := tview.NewFlex().SetDirection(tview.FlexRow)
+
+	body.AddItem(primitives.NewLeftAlignedTextView("Security"), 2, 1, false)
+
+	body.AddItem(primitives.NewLeftAlignedTextView("Security page coming soon").SetTextColor(helpers.DecredGreenColor), 0, 1, false)
+	
+	body.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEscape {
+			clearFocus()
+			return nil
+		}
+
+		return event
+	})
+
+	setFocus(body)
+	return body
+}

--- a/terminal/pages/settings.go
+++ b/terminal/pages/settings.go
@@ -1,0 +1,28 @@
+package pages
+
+import (
+	"github.com/gdamore/tcell"
+	"github.com/raedahgroup/godcr/terminal/primitives"
+	"github.com/rivo/tview"
+		"github.com/raedahgroup/godcr/terminal/helpers"
+)
+
+func settingsPage(setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
+	body := tview.NewFlex().SetDirection(tview.FlexRow)
+
+	body.AddItem(primitives.NewLeftAlignedTextView("Settings"), 2, 1, false)
+
+	body.AddItem(primitives.NewLeftAlignedTextView("Settings page coming soon").SetTextColor(helpers.DecredGreenColor), 0, 1, false)
+	
+	body.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEscape {
+			clearFocus()
+			return nil
+		}
+
+		return event
+	})
+
+	setFocus(body)
+	return body
+}

--- a/terminal/pages/settings.go
+++ b/terminal/pages/settings.go
@@ -2,9 +2,9 @@ package pages
 
 import (
 	"github.com/gdamore/tcell"
+	"github.com/raedahgroup/godcr/terminal/helpers"
 	"github.com/raedahgroup/godcr/terminal/primitives"
 	"github.com/rivo/tview"
-		"github.com/raedahgroup/godcr/terminal/helpers"
 )
 
 func settingsPage(setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
@@ -13,7 +13,7 @@ func settingsPage(setFocus func(p tview.Primitive) *tview.Application, clearFocu
 	body.AddItem(primitives.NewLeftAlignedTextView("Settings"), 2, 1, false)
 
 	body.AddItem(primitives.NewLeftAlignedTextView("Settings page coming soon").SetTextColor(helpers.DecredGreenColor), 0, 1, false)
-	
+
 	body.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEscape {
 			clearFocus()

--- a/terminal/primitives/list.go
+++ b/terminal/primitives/list.go
@@ -1,0 +1,521 @@
+package primitives
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gdamore/tcell"
+	"github.com/rivo/tview"
+)
+
+// listItem represents one item in a List.
+type listItem struct {
+	MainText      string // The main text of the list item.
+	SecondaryText string // A secondary text to be shown underneath the main text.
+	Shortcut      rune   // The key to select the list item directly, 0 if there is no shortcut.
+	Selected      func() // The optional function which is called when the item is selected.
+}
+
+// List displays rows of items, each of which can be selected.
+//
+// See https://github.com/rivo/tview/wiki/List for an example.
+type List struct {
+	*tview.Box
+
+	// The items of the list.
+	items []*listItem
+
+	// The index of the currently selected item.
+	currentItem int
+
+	// Whether or not to show the secondary item texts.
+	showSecondaryText bool
+
+	// Whether or not to show the secondary item texts.
+	showShortcut bool
+
+	// The item main text color.
+	mainTextColor tcell.Color
+
+	// The item secondary text color.
+	secondaryTextColor tcell.Color
+
+	// The item shortcut text color.
+	shortcutColor tcell.Color
+
+	// The text color for selected items.
+	selectedTextColor tcell.Color
+
+	// The background color for selected items.
+	selectedBackgroundColor tcell.Color
+
+	// If true, the selection is only shown when the list has focus.
+	selectedFocusOnly bool
+
+	// The number of list items skipped at the top before the first item is drawn.
+	offset int
+
+	// An optional function which is called when the user has navigated to a list
+	// item.
+	changed func(index int, mainText, secondaryText string, shortcut rune)
+
+	// An optional function which is called when a list item was selected. This
+	// function will be called even if the list item defines its own callback.
+	selected func(index int, mainText, secondaryText string, shortcut rune)
+
+	// An optional function which is called when the user presses the Escape key.
+	done func()
+}
+
+// NewList returns a new form.
+func NewList() *List {
+	return &List{
+		Box:                     tview.NewBox(),
+		showSecondaryText:       true,
+		showShortcut:       true,
+		mainTextColor:           tview.Styles.PrimaryTextColor,
+		secondaryTextColor:      tview.Styles.TertiaryTextColor,
+		shortcutColor:           tview.Styles.SecondaryTextColor,
+		selectedTextColor:       tview.Styles.PrimitiveBackgroundColor,
+		selectedBackgroundColor: tview.Styles.PrimaryTextColor,
+	}
+}
+
+// SetCurrentItem sets the currently selected item by its index, starting at 0
+// for the first item. If a negative index is provided, items are referred to
+// from the back (-1 = last item, -2 = second-to-last item, and so on). Out of
+// range indices are clamped to the beginning/end.
+//
+// Calling this function triggers a "changed" event if the selection changes.
+func (l *List) SetCurrentItem(index int) *List {
+	if index < 0 {
+		index = len(l.items) + index
+	}
+	if index >= len(l.items) {
+		index = len(l.items) - 1
+	}
+	if index < 0 {
+		index = 0
+	}
+	l.currentItem = index
+
+	if index != l.currentItem && l.changed != nil {
+		item := l.items[l.currentItem]
+		l.changed(l.currentItem, item.MainText, item.SecondaryText, item.Shortcut)
+	}
+
+	return l
+}
+
+// GetCurrentItem returns the index of the currently selected list item,
+// starting at 0 for the first item.
+func (l *List) GetCurrentItem() int {
+	return l.currentItem
+}
+
+// RemoveItem removes the item with the given index (starting at 0) from the
+// list. If a negative index is provided, items are referred to from the back
+// (-1 = last item, -2 = second-to-last item, and so on). Out of range indices
+// are clamped to the beginning/end, i.e. unless the list is empty, an item is
+// always removed.
+//
+// The currently selected item is shifted accordingly. If it is the one that is
+// removed, a "changed" event is fired.
+func (l *List) RemoveItem(index int) *List {
+	if len(l.items) == 0 {
+		return l
+	}
+
+	// Adjust index.
+	if index < 0 {
+		index = len(l.items) + index
+	}
+	if index >= len(l.items) {
+		index = len(l.items) - 1
+	}
+	if index < 0 {
+		index = 0
+	}
+
+	// Remove item.
+	l.items = append(l.items[:index], l.items[index+1:]...)
+
+	// If there is nothing left, we're done.
+	if len(l.items) == 0 {
+		return l
+	}
+
+	// Shift current item.
+	previousCurrentItem := l.currentItem
+	if l.currentItem >= index {
+		l.currentItem--
+	}
+
+	// Fire "changed" event for removed items.
+	if previousCurrentItem == index && l.changed != nil {
+		item := l.items[l.currentItem]
+		l.changed(l.currentItem, item.MainText, item.SecondaryText, item.Shortcut)
+	}
+
+	return l
+}
+
+// SetMainTextColor sets the color of the items' main text.
+func (l *List) SetMainTextColor(color tcell.Color) *List {
+	l.mainTextColor = color
+	return l
+}
+
+// SetSecondaryTextColor sets the color of the items' secondary text.
+func (l *List) SetSecondaryTextColor(color tcell.Color) *List {
+	l.secondaryTextColor = color
+	return l
+}
+
+// SetShortcutColor sets the color of the items' shortcut.
+func (l *List) SetShortcutColor(color tcell.Color) *List {
+	l.shortcutColor = color
+	return l
+}
+
+// SetSelectedTextColor sets the text color of selected items.
+func (l *List) SetSelectedTextColor(color tcell.Color) *List {
+	l.selectedTextColor = color
+	return l
+}
+
+// SetSelectedBackgroundColor sets the background color of selected items.
+func (l *List) SetSelectedBackgroundColor(color tcell.Color) *List {
+	l.selectedBackgroundColor = color
+	return l
+}
+
+// SetSelectedFocusOnly sets a flag which determines when the currently selected
+// list item is highlighted. If set to true, selected items are only highlighted
+// when the list has focus. If set to false, they are always highlighted.
+func (l *List) SetSelectedFocusOnly(focusOnly bool) *List {
+	l.selectedFocusOnly = focusOnly
+	return l
+}
+
+// ShowSecondaryText determines whether or not to show secondary item texts.
+func (l *List) ShowSecondaryText(show bool) *List {
+	l.showSecondaryText = show
+	return l
+}
+
+// ShowSecondaryText determines whether or not to show shortcut item texts.
+func (l *List) ShowShortcut(show bool) *List {
+	l.showShortcut = show
+	return l
+}
+
+// SetChangedFunc sets the function which is called when the user navigates to
+// a list item. The function receives the item's index in the list of items
+// (starting with 0), its main text, secondary text, and its shortcut rune.
+//
+// This function is also called when the first item is added or when
+// SetCurrentItem() is called.
+func (l *List) SetChangedFunc(handler func(index int, mainText string, secondaryText string, shortcut rune)) *List {
+	l.changed = handler
+	return l
+}
+
+// SetSelectedFunc sets the function which is called when the user selects a
+// list item by pressing Enter on the current selection. The function receives
+// the item's index in the list of items (starting with 0), its main text,
+// secondary text, and its shortcut rune.
+func (l *List) SetSelectedFunc(handler func(int, string, string, rune)) *List {
+	l.selected = handler
+	return l
+}
+
+// SetDoneFunc sets a function which is called when the user presses the Escape
+// key.
+func (l *List) SetDoneFunc(handler func()) *List {
+	l.done = handler
+	return l
+}
+
+// AddItem calls InsertItem() with an index of -1.
+func (l *List) AddItem(mainText, secondaryText string, shortcut rune, selected func()) *List {
+	l.InsertItem(-1, mainText, secondaryText, shortcut, selected)
+	return l
+}
+
+// InsertItem adds a new item to the list at the specified index. An index of 0
+// will insert the item at the beginning, an index of 1 before the second item,
+// and so on. An index of GetItemCount() or higher will insert the item at the
+// end of the list. Negative indices are also allowed: An index of -1 will
+// insert the item at the end of the list, an index of -2 before the last item,
+// and so on. An index of -GetItemCount()-1 or lower will insert the item at the
+// beginning.
+//
+// An item has a main text which will be highlighted when selected. It also has
+// a secondary text which is shown underneath the main text (if it is set to
+// visible) but which may remain empty.
+//
+// The shortcut is a key binding. If the specified rune is entered, the item
+// is selected immediately. Set to 0 for no binding.
+//
+// The "selected" callback will be invoked when the user selects the item. You
+// may provide nil if no such callback is needed or if all events are handled
+// through the selected callback set with SetSelectedFunc().
+//
+// The currently selected item will shift its position accordingly. If the list
+// was previously empty, a "changed" event is fired because the new item becomes
+// selected.
+func (l *List) InsertItem(index int, mainText, secondaryText string, shortcut rune, selected func()) *List {
+	item := &listItem{
+		MainText:      mainText,
+		SecondaryText: secondaryText,
+		Shortcut:      shortcut,
+		Selected:      selected,
+	}
+
+	// Shift index to range.
+	if index < 0 {
+		index = len(l.items) + index + 1
+	}
+	if index < 0 {
+		index = 0
+	} else if index > len(l.items) {
+		index = len(l.items)
+	}
+
+	// Shift current item.
+	if l.currentItem < len(l.items) && l.currentItem >= index {
+		l.currentItem++
+	}
+
+	// Insert item (make space for the new item, then shift and insert).
+	l.items = append(l.items, nil)
+	if index < len(l.items)-1 { // -1 because l.items has already grown by one item.
+		copy(l.items[index+1:], l.items[index:])
+	}
+	l.items[index] = item
+
+	// Fire a "change" event for the first item in the list.
+	if len(l.items) == 1 && l.changed != nil {
+		item := l.items[0]
+		l.changed(0, item.MainText, item.SecondaryText, item.Shortcut)
+	}
+
+	return l
+}
+
+// GetItemCount returns the number of items in the list.
+func (l *List) GetItemCount() int {
+	return len(l.items)
+}
+
+// GetItemText returns an item's texts (main and secondary). Panics if the index
+// is out of range.
+func (l *List) GetItemText(index int) (main, secondary string) {
+	return l.items[index].MainText, l.items[index].SecondaryText
+}
+
+// SetItemText sets an item's main and secondary text. Panics if the index is
+// out of range.
+func (l *List) SetItemText(index int, main, secondary string) *List {
+	item := l.items[index]
+	item.MainText = main
+	item.SecondaryText = secondary
+	return l
+}
+
+// FindItems searches the main and secondary texts for the given strings and
+// returns a list of item indices in which those strings are found. One of the
+// two search strings may be empty, it will then be ignored. Indices are always
+// returned in ascending order.
+//
+// If mustContainBoth is set to true, mainSearch must be contained in the main
+// text AND secondarySearch must be contained in the secondary text. If it is
+// false, only one of the two search strings must be contained.
+//
+// Set ignoreCase to true for case-insensitive search.
+func (l *List) FindItems(mainSearch, secondarySearch string, mustContainBoth, ignoreCase bool) (indices []int) {
+	if mainSearch == "" && secondarySearch == "" {
+		return
+	}
+
+	if ignoreCase {
+		mainSearch = strings.ToLower(mainSearch)
+		secondarySearch = strings.ToLower(secondarySearch)
+	}
+
+	for index, item := range l.items {
+		mainText := item.MainText
+		secondaryText := item.SecondaryText
+		if ignoreCase {
+			mainText = strings.ToLower(mainText)
+			secondaryText = strings.ToLower(secondaryText)
+		}
+
+		// strings.Contains() always returns true for a "" search.
+		mainContained := strings.Contains(mainText, mainSearch)
+		secondaryContained := strings.Contains(secondaryText, secondarySearch)
+		if mustContainBoth && mainContained && secondaryContained ||
+			!mustContainBoth && (mainText != "" && mainContained || secondaryText != "" && secondaryContained) {
+			indices = append(indices, index)
+		}
+	}
+
+	return
+}
+
+// Clear removes all items from the list.
+func (l *List) Clear() *List {
+	l.items = nil
+	l.currentItem = 0
+	return l
+}
+
+// Draw draws this primitive onto the screen.
+func (l *List) Draw(screen tcell.Screen) {
+	l.Box.Draw(screen)
+
+	// Determine the dimensions.
+	x, y, width, height := l.GetInnerRect()
+	bottomLimit := y + height
+
+	// Do we show any shortcuts?
+	var showShortcuts bool
+	for _, item := range l.items {
+		if item.Shortcut != 0 {
+			showShortcuts = true
+			x += 4
+			width -= 4
+			break
+		}
+	}
+
+	// Adjust offset to keep the current selection in view.
+	if l.currentItem < l.offset {
+		l.offset = l.currentItem
+	} else if l.showSecondaryText {
+		if 2*(l.currentItem-l.offset) >= height-1 {
+			l.offset = (2*l.currentItem + 3 - height) / 2
+		}
+	} else {
+		if l.currentItem-l.offset >= height {
+			l.offset = l.currentItem + 1 - height
+		}
+	}
+
+	// Draw the list items.
+	for index, item := range l.items {
+		if index < l.offset {
+			continue
+		}
+
+		if y >= bottomLimit {
+			break
+		}
+
+		// Shortcuts.
+		if showShortcuts && item.Shortcut != 0 && l.showShortcut!= false{
+			tview.Print(screen, fmt.Sprintf("(%s)", string(item.Shortcut)), x-5, y, 4, tview.AlignRight, l.shortcutColor)
+		}
+
+		// Main text.
+		tview.Print(screen, item.MainText, x, y, width, tview.AlignLeft, l.mainTextColor)
+
+		// Background color of selected text.
+		if index == l.currentItem && (!l.selectedFocusOnly || l.HasFocus()) {
+			textWidth := tview.StringWidth(item.MainText)
+			for bx := 0; bx < textWidth && bx < width; bx++ {
+				m, c, style, _ := screen.GetContent(x+bx, y)
+				fg, _, _ := style.Decompose()
+				if fg == l.mainTextColor {
+					fg = l.selectedTextColor
+				}
+				style = style.Background(l.selectedBackgroundColor).Foreground(fg)
+				screen.SetContent(x+bx, y, m, c, style)
+			}
+		}
+
+		y++
+
+		if y >= bottomLimit {
+			break
+		}
+
+		// Secondary text.
+		if l.showSecondaryText {
+			tview.Print(screen, item.SecondaryText, x, y, width, tview.AlignLeft, l.secondaryTextColor)
+			y++
+		}
+	}
+}
+
+// InputHandler returns the handler for this primitive.
+func (l *List) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+	return l.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+		previousItem := l.currentItem
+
+		switch key := event.Key(); key {
+		case tcell.KeyTab, tcell.KeyDown, tcell.KeyRight:
+			l.currentItem++
+		case tcell.KeyBacktab, tcell.KeyUp, tcell.KeyLeft:
+			l.currentItem--
+		case tcell.KeyHome:
+			l.currentItem = 0
+		case tcell.KeyEnd:
+			l.currentItem = len(l.items) - 1
+		case tcell.KeyPgDn:
+			l.currentItem += 5
+		case tcell.KeyPgUp:
+			l.currentItem -= 5
+		case tcell.KeyEnter:
+			if l.currentItem >= 0 && l.currentItem < len(l.items) {
+				item := l.items[l.currentItem]
+				if item.Selected != nil {
+					item.Selected()
+				}
+				if l.selected != nil {
+					l.selected(l.currentItem, item.MainText, item.SecondaryText, item.Shortcut)
+				}
+			}
+		case tcell.KeyEscape:
+			if l.done != nil {
+				l.done()
+			}
+		case tcell.KeyRune:
+			ch := event.Rune()
+			if ch != ' ' {
+				// It's not a space bar. Is it a shortcut?
+				var found bool
+				for index, item := range l.items {
+					if item.Shortcut == ch {
+						// We have a shortcut.
+						found = true
+						l.currentItem = index
+						break
+					}
+				}
+				if !found {
+					break
+				}
+			}
+			item := l.items[l.currentItem]
+			if item.Selected != nil {
+				item.Selected()
+			}
+			if l.selected != nil {
+				l.selected(l.currentItem, item.MainText, item.SecondaryText, item.Shortcut)
+			}
+		}
+
+		if l.currentItem < 0 {
+			l.currentItem = len(l.items) - 1
+		} else if l.currentItem >= len(l.items) {
+			l.currentItem = 0
+		}
+
+		if l.currentItem != previousItem && l.currentItem < len(l.items) && l.changed != nil {
+			item := l.items[l.currentItem]
+			l.changed(l.currentItem, item.MainText, item.SecondaryText, item.Shortcut)
+		}
+	})
+}

--- a/terminal/primitives/list.go
+++ b/terminal/primitives/list.go
@@ -72,7 +72,7 @@ func NewList() *List {
 	return &List{
 		Box:                     tview.NewBox(),
 		showSecondaryText:       true,
-		showShortcut:       true,
+		showShortcut:            true,
 		mainTextColor:           tview.Styles.PrimaryTextColor,
 		secondaryTextColor:      tview.Styles.TertiaryTextColor,
 		shortcutColor:           tview.Styles.SecondaryTextColor,
@@ -382,7 +382,7 @@ func (l *List) Draw(screen tcell.Screen) {
 	// Do we show any shortcuts?
 	var showShortcuts bool
 	for _, item := range l.items {
-		if item.Shortcut != 0 {
+		if item.Shortcut != 0 && l.showShortcut != false {
 			showShortcuts = true
 			x += 4
 			width -= 4
@@ -414,7 +414,7 @@ func (l *List) Draw(screen tcell.Screen) {
 		}
 
 		// Shortcuts.
-		if showShortcuts && item.Shortcut != 0 && l.showShortcut!= false{
+		if showShortcuts && item.Shortcut != 0 {
 			tview.Print(screen, fmt.Sprintf("(%s)", string(item.Shortcut)), x-5, y, 4, tview.AlignRight, l.shortcutColor)
 		}
 


### PR DESCRIPTION
fixes #310 and #334 

new nav option now have `coming soon` message
![image](https://user-images.githubusercontent.com/27733432/56449939-5cdf1700-6318-11e9-92cc-2eabefc22bbc.png)

exit by pressing esc from navigation menu or exit button
![image](https://user-images.githubusercontent.com/27733432/56497046-e5fe7580-64f3-11e9-951c-e087df8f8227.png)

shortcuts hide when a nav option has focus
![image](https://user-images.githubusercontent.com/27733432/56449913-2a351e80-6318-11e9-9520-92d23e5d1080.png)

*when focus is returned to the nav menu shortcuts are displayed
![image](https://user-images.githubusercontent.com/27733432/56449747-cd386900-6315-11e9-8358-422ddd33233a.png)

transaction history table column padding and fixed width
![image](https://user-images.githubusercontent.com/27733432/56538452-ff86d800-655a-11e9-97c9-b2ff89bb3be4.png)

*when a menu item is selected, the menu option text-colours are changed from white to gray and the shourtcuts keys are hidden also the border on the nav menu changes for 2lines border to a single line border.

![image](https://user-images.githubusercontent.com/27733432/56468934-f4cd2580-642a-11e9-9599-56fab79d863e.png)

*When focus is shifted to the menu option, the border is move to the right and when returned to the the nav manu, the border is move to the right.
![image](https://user-images.githubusercontent.com/27733432/56489786-ceff5980-64da-11e9-8ede-8b093df79ccb.png)

![image](https://user-images.githubusercontent.com/27733432/56489805-df173900-64da-11e9-9e44-d4f090a9caac.png)


