### PR TITLE
Display transaction history in pages on nuklear

### DIFF
--- a/nuklear/handler.go
+++ b/nuklear/handler.go
@@ -5,6 +5,7 @@ import (
 	"github.com/raedahgroup/godcr/app"
 	"github.com/raedahgroup/godcr/app/walletcore"
 	"github.com/raedahgroup/godcr/nuklear/pagehandlers"
+	"github.com/raedahgroup/godcr/nuklear/pagehandlers/transaction"
 	"github.com/raedahgroup/godcr/nuklear/styles"
 	"github.com/raedahgroup/godcr/nuklear/widgets"
 )
@@ -62,7 +63,7 @@ func getNavPages() []navPage {
 		{
 			name:    "history",
 			label:   "History",
-			handler: &pagehandlers.HistoryHandler{},
+			handler: &transaction.HistoryHandler{},
 		},
 		{
 			name:    "send",

--- a/nuklear/pagehandlers/sync.go
+++ b/nuklear/pagehandlers/sync.go
@@ -91,6 +91,9 @@ func (s *SyncHandler) Render(window *nucular.Window, changePage func(*nucular.Wi
 		return
 	}
 
+	changePage(window, "overview")
+	return
+
 	widgets.NoScrollGroupWindow("sync-page", window, func(pageWindow *widgets.Window) {
 		pageWindow.Master().Style().GroupWindow.Padding = image.Point{10, 10}
 		pageWindow.AddHorizontalSpace(20)

--- a/nuklear/pagehandlers/sync.go
+++ b/nuklear/pagehandlers/sync.go
@@ -91,9 +91,6 @@ func (s *SyncHandler) Render(window *nucular.Window, changePage func(*nucular.Wi
 		return
 	}
 
-	changePage(window, "overview")
-	return
-
 	widgets.NoScrollGroupWindow("sync-page", window, func(pageWindow *widgets.Window) {
 		pageWindow.Master().Style().GroupWindow.Padding = image.Point{10, 10}
 		pageWindow.AddHorizontalSpace(20)

--- a/nuklear/pagehandlers/transaction/history.go
+++ b/nuklear/pagehandlers/transaction/history.go
@@ -1,0 +1,139 @@
+package transaction
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aarzilli/nucular"
+	"github.com/raedahgroup/godcr/app/walletcore"
+	"github.com/raedahgroup/godcr/nuklear/styles"
+	"github.com/raedahgroup/godcr/nuklear/widgets"
+)
+
+type paginationData struct {
+	itemsPerPage    int
+	nextBlockHeight int32
+	endBlockHeight  int32
+}
+
+type HistoryHandler struct {
+	fetchHistoryError      error
+	ctx                    context.Context
+	transactions           []*walletcore.Transaction
+	isFetchingTransactions bool
+	isRendering            bool
+	paginationData         paginationData
+
+	selectedTxHash      string
+	selectedTxDetails   *walletcore.TransactionDetails
+	isFetchingTxDetails bool
+	fetchTxDetailsError error
+
+	wallet walletcore.Wallet
+}
+
+func (handler *HistoryHandler) BeforeRender(wallet walletcore.Wallet, refreshWindowDisplay func()) bool {
+	// todo: caller should ideally pass a context parameter, propagated from main.go
+	handler.ctx = context.Background()
+
+	handler.clearTxDetails()
+
+	handler.fetchHistoryError = nil
+	handler.transactions = nil
+	handler.isRendering = false
+
+	handler.wallet = wallet
+
+	handler.paginationData = paginationData{
+		nextBlockHeight: -1,
+		endBlockHeight:  0,
+		itemsPerPage:    walletcore.TransactionHistoryCountPerPage,
+	}
+
+	return true
+}
+
+func (handler *HistoryHandler) Render(window *nucular.Window) {
+	if handler.selectedTxHash == "" {
+		if !handler.isRendering {
+			handler.isRendering = true
+			go handler.fetchTransactions(window)
+		}
+		handler.renderHistoryPage(window)
+		return
+	}
+	handler.renderTransactionDetailsPage(window)
+}
+
+func (handler *HistoryHandler) renderHistoryPage(window *nucular.Window) {
+	widgets.PageContentWindowDefaultPadding("History", window, func(contentWindow *widgets.Window) {
+		if handler.fetchHistoryError != nil {
+			contentWindow.DisplayErrorMessage("Error fetching txs", handler.fetchHistoryError)
+		} else if len(handler.transactions) > 0 {
+			handler.displayTransactions(contentWindow)
+		}
+
+		// show loading indicator if tx is being fetched
+		if handler.isFetchingTransactions {
+			contentWindow.DisplayIsLoadingMessage()
+		}
+	})
+}
+
+func (handler *HistoryHandler) fetchTransactions(window *nucular.Window) {
+	handler.isFetchingTransactions = true
+	window.Master().Changed()
+
+	transactions, endBlockHeight, err := handler.wallet.TransactionHistory(handler.ctx, handler.paginationData.nextBlockHeight,
+		handler.paginationData.itemsPerPage)
+
+	handler.fetchHistoryError = err
+	handler.transactions = append(handler.transactions, transactions...)
+
+	handler.paginationData.endBlockHeight = endBlockHeight
+	handler.paginationData.nextBlockHeight = endBlockHeight - 1
+
+	window.Master().Changed()
+
+	handler.isFetchingTransactions = false
+}
+
+func (handler *HistoryHandler) displayTransactions(contentWindow *widgets.Window) {
+	historyTable := widgets.NewTable()
+
+	// render table header with nav font
+	historyTable.AddRowWithFont(styles.NavFont,
+		widgets.NewLabelTableCell("#", "LC"),
+		widgets.NewLabelTableCell("Date", "LC"),
+		widgets.NewLabelTableCell("Direction", "LC"),
+		widgets.NewLabelTableCell("Amount", "LC"),
+		widgets.NewLabelTableCell("Fee", "LC"),
+		widgets.NewLabelTableCell("Type", "LC"),
+		widgets.NewLabelTableCell("Hash", "LC"),
+	)
+
+	for i, tx := range handler.transactions {
+		historyTable.AddRow(
+			widgets.NewLabelTableCell(fmt.Sprintf("%d", i+1), "LC"),
+			widgets.NewLabelTableCell(tx.FormattedTime, "LC"),
+			widgets.NewLabelTableCell(tx.Direction.String(), "LC"),
+			widgets.NewLabelTableCell(tx.Amount, "RC"),
+			widgets.NewLabelTableCell(tx.Fee, "RC"),
+			widgets.NewLabelTableCell(tx.Type, "LC"),
+			widgets.NewLinkTableCell(tx.Hash, "Click to see transaction details", handler.gotoTransactionDetails),
+		)
+	}
+
+	historyTable.Render(contentWindow)
+
+	if !handler.isFetchingTransactions {
+		contentWindow.Row(40).Static(130)
+		contentWindow.AddButtonToCurrentRow("Load more", func() {
+			handler.gotoNextPage(contentWindow)
+		})
+	}
+}
+
+func (handler *HistoryHandler) gotoNextPage(window *widgets.Window) {
+	go handler.fetchTransactions(window.Window)
+}

--- a/nuklear/pagehandlers/transaction/history.go
+++ b/nuklear/pagehandlers/transaction/history.go
@@ -11,15 +11,21 @@ import (
 )
 
 type paginationData struct {
+	currentPage     int
 	itemsPerPage    int
 	nextBlockHeight int32
 	endBlockHeight  int32
 }
 
+type transactionsData struct {
+	numberingStartsAt int
+	transactions      []*walletcore.Transaction
+}
+
 type HistoryHandler struct {
 	fetchHistoryError      error
 	ctx                    context.Context
-	transactions           []*walletcore.Transaction
+	transactions           []*transactionsData // each []*walletcore.Transaction slice is a page
 	isFetchingTransactions bool
 	isRendering            bool
 	paginationData         paginationData
@@ -36,19 +42,20 @@ func (handler *HistoryHandler) BeforeRender(wallet walletcore.Wallet, refreshWin
 	// todo: caller should ideally pass a context parameter, propagated from main.go
 	handler.ctx = context.Background()
 
+	handler.wallet = wallet
+
+	handler.paginationData = paginationData{
+		currentPage:     0,
+		nextBlockHeight: -1,
+		endBlockHeight:  0,
+		itemsPerPage:    walletcore.TransactionHistoryCountPerPage,
+	}
+
 	handler.clearTxDetails()
 
 	handler.fetchHistoryError = nil
 	handler.transactions = nil
 	handler.isRendering = false
-
-	handler.wallet = wallet
-
-	handler.paginationData = paginationData{
-		nextBlockHeight: -1,
-		endBlockHeight:  0,
-		itemsPerPage:    walletcore.TransactionHistoryCountPerPage,
-	}
 
 	return true
 }
@@ -65,21 +72,6 @@ func (handler *HistoryHandler) Render(window *nucular.Window) {
 	handler.renderTransactionDetailsPage(window)
 }
 
-func (handler *HistoryHandler) renderHistoryPage(window *nucular.Window) {
-	widgets.PageContentWindowDefaultPadding("History", window, func(contentWindow *widgets.Window) {
-		if handler.fetchHistoryError != nil {
-			contentWindow.DisplayErrorMessage("Error fetching txs", handler.fetchHistoryError)
-		} else if len(handler.transactions) > 0 {
-			handler.displayTransactions(contentWindow)
-		}
-
-		// show loading indicator if tx is being fetched
-		if handler.isFetchingTransactions {
-			contentWindow.DisplayIsLoadingMessage()
-		}
-	})
-}
-
 func (handler *HistoryHandler) fetchTransactions(window *nucular.Window) {
 	handler.isFetchingTransactions = true
 	window.Master().Changed()
@@ -87,15 +79,42 @@ func (handler *HistoryHandler) fetchTransactions(window *nucular.Window) {
 	transactions, endBlockHeight, err := handler.wallet.TransactionHistory(handler.ctx, handler.paginationData.nextBlockHeight,
 		handler.paginationData.itemsPerPage)
 
+	numberingStartsAt := 1
+	if len(handler.transactions) > 0 {
+		lastSavedTransaction := handler.transactions[len(handler.transactions)-1]
+		numberingStartsAt = lastSavedTransaction.numberingStartsAt + len(lastSavedTransaction.transactions)
+	}
+
+	transactionsData := &transactionsData{
+		numberingStartsAt: numberingStartsAt,
+		transactions:      transactions,
+	}
+
 	handler.fetchHistoryError = err
-	handler.transactions = append(handler.transactions, transactions...)
+	handler.transactions = append(handler.transactions, transactionsData)
 
 	handler.paginationData.endBlockHeight = endBlockHeight
 	handler.paginationData.nextBlockHeight = endBlockHeight - 1
+	handler.paginationData.currentPage += 1
 
 	window.Master().Changed()
 
 	handler.isFetchingTransactions = false
+}
+
+func (handler *HistoryHandler) renderHistoryPage(window *nucular.Window) {
+	widgets.PageContentWindowDefaultPadding("History", window, func(contentWindow *widgets.Window) {
+		if handler.isFetchingTransactions {
+			contentWindow.DisplayIsLoadingMessage()
+			return
+		}
+
+		if handler.fetchHistoryError != nil {
+			contentWindow.DisplayErrorMessage("Error fetching txs", handler.fetchHistoryError)
+		} else if len(handler.transactions) > 0 {
+			handler.displayTransactions(contentWindow)
+		}
+	})
 }
 
 func (handler *HistoryHandler) displayTransactions(contentWindow *widgets.Window) {
@@ -112,9 +131,13 @@ func (handler *HistoryHandler) displayTransactions(contentWindow *widgets.Window
 		widgets.NewLabelTableCell("Hash", "LC"),
 	)
 
-	for i, tx := range handler.transactions {
+	// get current page transactions
+	transactions := handler.transactions[handler.paginationData.currentPage-1]
+	currentNumber := transactions.numberingStartsAt
+
+	for _, tx := range transactions.transactions {
 		historyTable.AddRow(
-			widgets.NewLabelTableCell(fmt.Sprintf("%d", i+1), "LC"),
+			widgets.NewLabelTableCell(fmt.Sprintf("%d", currentNumber), "LC"),
 			widgets.NewLabelTableCell(tx.FormattedTime, "LC"),
 			widgets.NewLabelTableCell(tx.Direction.String(), "LC"),
 			widgets.NewLabelTableCell(tx.Amount, "RC"),
@@ -122,18 +145,42 @@ func (handler *HistoryHandler) displayTransactions(contentWindow *widgets.Window
 			widgets.NewLabelTableCell(tx.Type, "LC"),
 			widgets.NewLinkTableCell(tx.Hash, "Click to see transaction details", handler.gotoTransactionDetails),
 		)
+		currentNumber++
 	}
 
 	historyTable.Render(contentWindow)
 
 	if !handler.isFetchingTransactions {
-		contentWindow.Row(40).Static(130)
-		contentWindow.AddButtonToCurrentRow("Load more", func() {
-			handler.gotoNextPage(contentWindow)
+		contentWindow.Row(40).Static(130, 130)
+		// show previous button only if current page is greater than 1
+		if handler.paginationData.currentPage > 1 {
+			contentWindow.AddButtonToCurrentRow("Previous", func() {
+				handler.loadPreviousPage(contentWindow)
+			})
+		}
+
+		contentWindow.AddButtonToCurrentRow("Next Page", func() {
+			handler.loadNextPage(window)
 		})
 	}
 }
 
-func (handler *HistoryHandler) gotoNextPage(window *widgets.Window) {
+func (handler *HistoryHandler) loadNextPage(window *widgets.Window) {
+	// check if transactions for the page we are navigating to is already loaded
+	if len(handler.transactions) >= handler.paginationData.currentPage+1 {
+		handler.paginationData.currentPage++
+		window.Master().Changed()
+		return
+	}
 	go handler.fetchTransactions(window.Window)
+}
+
+func (handler *HistoryHandler) loadPreviousPage(window *widgets.Window) {
+	defer window.Master().Changed()
+
+	// perform this check even if it's unlikely to occur
+	if handler.paginationData.currentPage == 1 {
+		return
+	}
+	handler.paginationData.currentPage -= 1
 }

--- a/nuklear/pagehandlers/transaction/transaction_details.go
+++ b/nuklear/pagehandlers/transaction/transaction_details.go
@@ -1,130 +1,19 @@
-package pagehandlers
+package transaction
 
 import (
-	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/aarzilli/nucular"
 	"github.com/decred/dcrd/dcrutil"
-	"github.com/raedahgroup/godcr/app/walletcore"
 	"github.com/raedahgroup/godcr/nuklear/styles"
 	"github.com/raedahgroup/godcr/nuklear/widgets"
 )
-
-type HistoryHandler struct {
-	fetchHistoryError      error
-	ctx                    context.Context
-	transactions           []*walletcore.Transaction
-	isFetchingTransactions bool
-	nextBlockHeight        int32
-
-	selectedTxHash      string
-	selectedTxDetails   *walletcore.TransactionDetails
-	isFetchingTxDetails bool
-	fetchTxDetailsError error
-
-	wallet walletcore.Wallet
-}
-
-func (handler *HistoryHandler) BeforeRender(wallet walletcore.Wallet, refreshWindowDisplay func()) bool {
-	// todo: caller should ideally pass a context parameter, propagated from main.go
-	handler.ctx = context.Background()
-
-	handler.isFetchingTransactions = true
-	handler.fetchHistoryError = nil
-	handler.transactions = nil
-
-	handler.wallet = wallet
-
-	go handler.fetchTransactions(wallet, refreshWindowDisplay)
-
-	handler.clearTxDetails()
-
-	return true
-}
-
-func (handler *HistoryHandler) fetchTransactions(wallet walletcore.Wallet, refreshWindowDisplay func()) {
-	if len(handler.transactions) == 0 {
-		// first page
-		handler.nextBlockHeight = -1
-	}
-
-	transactions, endBlockHeight, err := wallet.TransactionHistory(handler.ctx, handler.nextBlockHeight,
-		walletcore.TransactionHistoryCountPerPage)
-
-	// next start block should be the block immediately preceding the current end block
-	handler.fetchHistoryError = err
-	handler.transactions = append(handler.transactions, transactions...)
-	handler.nextBlockHeight = endBlockHeight - 1
-
-	refreshWindowDisplay()
-
-	// load more if possible
-	if handler.nextBlockHeight >= 0 {
-		handler.fetchTransactions(wallet, refreshWindowDisplay)
-	} else {
-		handler.isFetchingTransactions = false
-	}
-}
 
 func (handler *HistoryHandler) clearTxDetails() {
 	handler.selectedTxHash = ""
 	handler.selectedTxDetails = nil
 	handler.isFetchingTxDetails = false
 	handler.fetchTxDetailsError = nil
-}
-
-func (handler *HistoryHandler) Render(window *nucular.Window) {
-	if handler.selectedTxHash == "" {
-		handler.renderHistoryPage(window)
-		return
-	}
-	handler.renderTransactionDetailsPage(window)
-}
-
-func (handler *HistoryHandler) renderHistoryPage(window *nucular.Window) {
-	widgets.PageContentWindowDefaultPadding("History", window, func(contentWindow *widgets.Window) {
-		if handler.fetchHistoryError != nil {
-			contentWindow.DisplayErrorMessage("Error fetching txs", handler.fetchHistoryError)
-		} else if len(handler.transactions) > 0 {
-			handler.displayTransactions(contentWindow)
-		}
-
-		// show loading indicator if tx is being fetched
-		if handler.isFetchingTransactions {
-			contentWindow.DisplayIsLoadingMessage()
-		}
-	})
-}
-
-func (handler *HistoryHandler) displayTransactions(contentWindow *widgets.Window) {
-	historyTable := widgets.NewTable()
-
-	// render table header with nav font
-	historyTable.AddRowWithFont(styles.NavFont,
-		widgets.NewLabelTableCell("#", "LC"),
-		widgets.NewLabelTableCell("Date", "LC"),
-		widgets.NewLabelTableCell("Direction", "LC"),
-		widgets.NewLabelTableCell("Amount", "LC"),
-		widgets.NewLabelTableCell("Fee", "LC"),
-		widgets.NewLabelTableCell("Type", "LC"),
-		widgets.NewLabelTableCell("Hash", "LC"),
-	)
-
-	for i, tx := range handler.transactions {
-		historyTable.AddRow(
-			widgets.NewLabelTableCell(fmt.Sprintf("%d", i+1), "LC"),
-			widgets.NewLabelTableCell(tx.FormattedTime, "LC"),
-			widgets.NewLabelTableCell(tx.Direction.String(), "LC"),
-			widgets.NewLabelTableCell(tx.Amount, "RC"),
-			widgets.NewLabelTableCell(tx.Fee, "RC"),
-			widgets.NewLabelTableCell(tx.Type, "LC"),
-			widgets.NewLinkTableCell(tx.Hash, "Click to see transaction details", handler.gotoTransactionDetails),
-		)
-	}
-
-	historyTable.Render(contentWindow)
 }
 
 func (handler *HistoryHandler) gotoTransactionDetails(txHash string, window *widgets.Window) {


### PR DESCRIPTION
This fetches and displays transaction history in pages on the history page of the nuklear interface. In navigating using "previous" and "next" buttons, this PR makes sure that already fetched transaction pages are just re-rendered instead of  fetched again from the walletrpc server. 

It should be noted that the nucular/nuklear project does not provide us with a scroll listener, so this PR makes use of "next" and "previous" buttons to navigate through pages instead of the infinite scrolling suggested by #314   

Fixes #314 

![Screenshot from 2019-04-22 18-01-23](https://user-images.githubusercontent.com/42093751/56512954-cf264600-6528-11e9-864d-18e2e0d85fdc.png)
![Screenshot from 2019-04-22 18-01-44](https://user-images.githubusercontent.com/42093751/56512955-cf264600-6528-11e9-9f76-2d674cfee84e.png)

