### PR TITLE
Nuklear Persistent Sync UI

### DIFF
--- a/nuklear/handler.go
+++ b/nuklear/handler.go
@@ -42,13 +42,9 @@ type navPageHandler interface {
 func getStandalonePages() []standalonePage {
 	return []standalonePage{
 		{
-			name:    "sync",
-			handler: &pagehandlers.SyncHandler{},
+			name:    "createwallet",
+			handler: &pagehandlers.CreateWalletHandler{},
 		},
-		//{
-		//	name:    "createwallet",
-		//	handler: &pagehandlers.CreateWalletHandler{},
-		//},
 	}
 }
 

--- a/nuklear/handler.go
+++ b/nuklear/handler.go
@@ -2,22 +2,11 @@ package nuklear
 
 import (
 	"github.com/aarzilli/nucular"
-	"github.com/raedahgroup/godcr/app"
 	"github.com/raedahgroup/godcr/app/walletcore"
 	"github.com/raedahgroup/godcr/nuklear/pagehandlers"
 	"github.com/raedahgroup/godcr/nuklear/styles"
 	"github.com/raedahgroup/godcr/nuklear/widgets"
 )
-
-type standalonePage struct {
-	name    string
-	handler standalonePageHandler
-}
-
-type standalonePageHandler interface {
-	BeforeRender(walletMiddleware app.WalletMiddleware, refreshWindowDisplay func())
-	Render(*nucular.Window, func(*nucular.Window, string))
-}
 
 type navPage struct {
 	name    string
@@ -37,15 +26,6 @@ type navPageHandler interface {
 	// It is usually called several times not only when the page is navigated to.
 	// For example, this method will be triggered whenever the mouse is moved, causing the window to repaint.
 	Render(window *nucular.Window)
-}
-
-func getStandalonePages() []standalonePage {
-	return []standalonePage{
-		{
-			name:    "createwallet",
-			handler: &pagehandlers.CreateWalletHandler{},
-		},
-	}
 }
 
 func getNavPages() []navPage {


### PR DESCRIPTION
This fixes #337 by making sync UI part of the main nuklear UI.  It also fixes #336 by refactoring code to make sure that on page change the flashing that was prevalent no longer occurs.

![Screenshot from 2019-04-24 14-16-53](https://user-images.githubusercontent.com/42093751/56662337-a4103380-669b-11e9-8a8c-8e1659bb9aa6.png)
 