### PR TITLE
display nuklear transaction details on one column

### DIFF
--- a/nuklear/pagehandlers/transaction_details.go
+++ b/nuklear/pagehandlers/transaction_details.go
@@ -35,12 +35,6 @@ func (handler *HistoryHandler) renderTransactionDetailsPage(window *nucular.Wind
 	}
 
 	widgets.PageContentWindowDefaultPadding("Transaction Details", window, func(contentWindow *widgets.Window) {
-		contentWindow.AddButton("Back", func() {
-			// clear tx details data so that history page is re-displayed
-			handler.clearTxDetails()
-			contentWindow.Master().Changed()
-		})
-
 		if handler.fetchTxDetailsError != nil {
 			contentWindow.DisplayErrorMessage("Error fetching transaction details", handler.fetchTxDetailsError)
 		} else if handler.selectedTxDetails != nil {
@@ -52,12 +46,29 @@ func (handler *HistoryHandler) renderTransactionDetailsPage(window *nucular.Wind
 }
 
 func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.Window) {
-
 	// Create row to hold tx details in 2 columns
 	// Each column will display data about the tx in a group window.
 	// Row height is calculated based on the max group items total height
 	contentWindow.Window.Row(handler.calculateTxDetailsPageHeight()).Static(670)
 	widgets.NoScrollGroupWindow("tx-details-group-1", contentWindow.Window, func(window *widgets.Window) {
+		breadcrumb := []*widgets.Breadcrumb{
+			{
+				Text: "History",
+				Action: func(text string, window *widgets.Window) {
+					handler.clearTxDetails()
+					window.Master().Changed()
+				},
+			},
+			{
+				Text:   "Transaction Details",
+				Action: nil,
+			},
+		}
+		window.AddBreadcrumb(breadcrumb)
+		if handler.selectedTxHash == "" {
+			return
+		}
+
 		txDetailsTable1 := widgets.NewTable()
 		txDetailsTable1.AddRow(
 			widgets.NewLabelTableCell("Confirmations", "LC"),

--- a/nuklear/pagehandlers/transaction_details.go
+++ b/nuklear/pagehandlers/transaction_details.go
@@ -10,6 +10,10 @@ import (
 	"github.com/raedahgroup/godcr/nuklear/widgets"
 )
 
+const (
+	dividerHeight = 10
+)
+
 func (handler *HistoryHandler) clearTxDetails() {
 	handler.selectedTxHash = ""
 	handler.selectedTxDetails = nil
@@ -44,10 +48,100 @@ func (handler *HistoryHandler) renderTransactionDetailsPage(window *nucular.Wind
 }
 
 func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.Window) {
-	// Create row to hold tx details in 2 columns
-	// Each column will display data about the tx in a group window.
-	// Row height is calculated based on the max group items total height
-	contentWindow.Window.Row(handler.calculateTxDetailsPageHeight()).Static(730)
+	if handler.selectedTxHash == "" {
+		return
+	}
+
+	var status string
+	if handler.selectedTxDetails.Confirmations >= 2 {
+		status = "Confirmed"
+	} else {
+		status = "Unconfirmed"
+	}
+
+	// we create our tables here so that we are able to calculate our window height using table data
+	txDetailsTable := widgets.NewTable()
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Confirmations", "LC"),
+		widgets.NewLabelTableCell(strconv.Itoa(int(handler.selectedTxDetails.Confirmations)), "LC"),
+	)
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Hash", "LC"),
+		widgets.NewLabelTableCell(handler.selectedTxDetails.Hash, "LC"),
+	)
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Block Height", "LC"),
+		widgets.NewLabelTableCell(strconv.Itoa(int(handler.selectedTxDetails.BlockHeight)), "LC"),
+	)
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Direction", "LC"),
+		widgets.NewLabelTableCell(handler.selectedTxDetails.Direction.String(), "LC"),
+	)
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Type", "LC"),
+		widgets.NewLabelTableCell(handler.selectedTxDetails.Type, "LC"),
+	)
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Amount", "LC"),
+		widgets.NewLabelTableCell(dcrutil.Amount(handler.selectedTxDetails.Amount).String(), "LC"),
+	)
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Size", "LC"),
+		widgets.NewLabelTableCell(strconv.Itoa(handler.selectedTxDetails.Size)+" Bytes", "LC"),
+	)
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Fee", "LC"),
+		widgets.NewLabelTableCell(dcrutil.Amount(handler.selectedTxDetails.Fee).String(), "LC"),
+	)
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Fee Rate", "LC"),
+		widgets.NewLabelTableCell(dcrutil.Amount(handler.selectedTxDetails.FeeRate).String(), "LC"),
+	)
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Status", "LC"),
+		widgets.NewLabelTableCell(status, "LC"),
+	)
+	txDetailsTable.AddRow(
+		widgets.NewLabelTableCell("Date", "LC"),
+		widgets.NewLabelTableCell(fmt.Sprintf("%s UTC", handler.selectedTxDetails.LongTime), "LC"),
+	)
+
+	txInputsTable := widgets.NewTable()
+	txInputsTable.AddRowWithFont(styles.NavFont,
+		widgets.NewLabelTableCell("Previous Outpoint", "LC"),
+		widgets.NewLabelTableCell("Account", "LC"),
+		widgets.NewLabelTableCell("Amount", "LC"),
+	)
+
+	for _, input := range handler.selectedTxDetails.Inputs {
+		txInputsTable.AddRow(
+			widgets.NewLabelTableCell(input.PreviousTransactionHash, "LC"),
+			widgets.NewLabelTableCell(input.AccountName, "LC"),
+			widgets.NewLabelTableCell(dcrutil.Amount(input.Amount).String(), "LC"),
+		)
+	}
+
+	txOutputsTable := widgets.NewTable()
+	txOutputsTable.AddRowWithFont(styles.NavFont,
+		widgets.NewLabelTableCell("Address", "LC"),
+		widgets.NewLabelTableCell("Account", "LC"),
+		widgets.NewLabelTableCell("Value", "LC"),
+		widgets.NewLabelTableCell("Type", "LC"),
+	)
+
+	for _, output := range handler.selectedTxDetails.Outputs {
+		txOutputsTable.AddRow(
+			widgets.NewLabelTableCell(output.Address, "LC"),
+			widgets.NewLabelTableCell(output.AccountName, "LC"),
+			widgets.NewLabelTableCell(dcrutil.Amount(output.Amount).String(), "LC"),
+			widgets.NewLabelTableCell(output.ScriptType, "LC"),
+		)
+	}
+
+	// calculate additionally used horizontal space
+	hSpace := (dividerHeight * 2) + (widgets.TableRowHeight * 3) // 2 horizontal spaces + 3 lines of text (2 table headers, 1 breadcrumb)
+
+	contentWindow.Window.Row(handler.calculateTxDetailsPageHeight(txDetailsTable.Height(), txInputsTable.Height(), txOutputsTable.Height(), hSpace)).Static(730)
 	widgets.NoScrollGroupWindow("tx-details-group-1", contentWindow.Window, func(window *widgets.Window) {
 		breadcrumb := []*widgets.Breadcrumb{
 			{
@@ -63,111 +157,26 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 			},
 		}
 		window.AddBreadcrumb(breadcrumb)
-		if handler.selectedTxHash == "" {
-			return
-		}
 
-		var status string
-		if handler.selectedTxDetails.Confirmations >= 2 {
-			status = "Confirmed"
-		} else {
-			status = "Unconfirmed"
-		}
-
-		txDetailsTable := widgets.NewTable()
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Confirmations", "LC"),
-			widgets.NewLabelTableCell(strconv.Itoa(int(handler.selectedTxDetails.Confirmations)), "LC"),
-		)
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Hash", "LC"),
-			widgets.NewLabelTableCell(handler.selectedTxDetails.Hash, "LC"),
-		)
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Block Height", "LC"),
-			widgets.NewLabelTableCell(strconv.Itoa(int(handler.selectedTxDetails.BlockHeight)), "LC"),
-		)
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Direction", "LC"),
-			widgets.NewLabelTableCell(handler.selectedTxDetails.Direction.String(), "LC"),
-		)
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Type", "LC"),
-			widgets.NewLabelTableCell(handler.selectedTxDetails.Type, "LC"),
-		)
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Amount", "LC"),
-			widgets.NewLabelTableCell(dcrutil.Amount(handler.selectedTxDetails.Amount).String(), "LC"),
-		)
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Size", "LC"),
-			widgets.NewLabelTableCell(strconv.Itoa(handler.selectedTxDetails.Size)+" Bytes", "LC"),
-		)
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Fee", "LC"),
-			widgets.NewLabelTableCell(dcrutil.Amount(handler.selectedTxDetails.Fee).String(), "LC"),
-		)
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Fee Rate", "LC"),
-			widgets.NewLabelTableCell(dcrutil.Amount(handler.selectedTxDetails.FeeRate).String(), "LC"),
-		)
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Status", "LC"),
-			widgets.NewLabelTableCell(status, "LC"),
-		)
-		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Date", "LC"),
-			widgets.NewLabelTableCell(fmt.Sprintf("%s UTC", handler.selectedTxDetails.LongTime), "LC"),
-		)
 		txDetailsTable.Render(window)
 
-		window.AddHorizontalSpace(10)
+		window.AddHorizontalSpace(dividerHeight)
 		window.AddLabelWithFont("Inputs", "LC", styles.BoldPageContentFont)
-
-		txInputsTable := widgets.NewTable()
-		txInputsTable.AddRowWithFont(styles.NavFont,
-			widgets.NewLabelTableCell("Previous Outpoint", "LC"),
-			widgets.NewLabelTableCell("Account", "LC"),
-			widgets.NewLabelTableCell("Amount", "LC"),
-		)
-
-		for _, input := range handler.selectedTxDetails.Inputs {
-			txInputsTable.AddRow(
-				widgets.NewLabelTableCell(input.PreviousTransactionHash, "LC"),
-				widgets.NewLabelTableCell(input.AccountName, "LC"),
-				widgets.NewLabelTableCell(dcrutil.Amount(input.Amount).String(), "LC"),
-			)
-		}
 		txInputsTable.Render(window)
 
-		window.AddHorizontalSpace(10)
+		window.AddHorizontalSpace(dividerHeight)
 		window.AddLabelWithFont("Outputs", "LC", styles.BoldPageContentFont)
 
-		txOutputsTable := widgets.NewTable()
-		txOutputsTable.AddRowWithFont(styles.NavFont,
-			widgets.NewLabelTableCell("Address", "LC"),
-			widgets.NewLabelTableCell("Account", "LC"),
-			widgets.NewLabelTableCell("Value", "LC"),
-			widgets.NewLabelTableCell("Type", "LC"),
-		)
-
-		for _, output := range handler.selectedTxDetails.Outputs {
-			txOutputsTable.AddRow(
-				widgets.NewLabelTableCell(output.Address, "LC"),
-				widgets.NewLabelTableCell(output.AccountName, "LC"),
-				widgets.NewLabelTableCell(dcrutil.Amount(output.Amount).String(), "LC"),
-				widgets.NewLabelTableCell(output.ScriptType, "LC"),
-			)
-		}
 		txOutputsTable.Render(window)
 	})
 }
 
-func (handler *HistoryHandler) calculateTxDetailsPageHeight() int {
-	firstSectionHeight := 460
-	lineHeight := 27
-	outputsHeight := len(handler.selectedTxDetails.Outputs) * lineHeight
-	inputsHeight := len(handler.selectedTxDetails.Inputs) * lineHeight
+func (handler *HistoryHandler) calculateTxDetailsPageHeight(tableHeights ...int) int {
+	var totalTableHeight int
 
-	return firstSectionHeight + outputsHeight + inputsHeight
+	for i := range tableHeights {
+		totalTableHeight += tableHeights[i]
+	}
+
+	return totalTableHeight
 }

--- a/nuklear/pagehandlers/transaction_details.go
+++ b/nuklear/pagehandlers/transaction_details.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"fmt"
+
 	"github.com/aarzilli/nucular"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/raedahgroup/godcr/nuklear/styles"
@@ -50,11 +52,12 @@ func (handler *HistoryHandler) renderTransactionDetailsPage(window *nucular.Wind
 }
 
 func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.Window) {
+
 	// Create row to hold tx details in 2 columns
 	// Each column will display data about the tx in a group window.
 	// Row height is calculated based on the max group items total height
-	contentWindow.Window.Row(handler.calculateTxDetailsPageHeight()).Static(670, 700)
-	widgets.NoScrollGroupWindow("tx-details-col-1", contentWindow.Window, func(window *widgets.Window) {
+	contentWindow.Window.Row(handler.calculateTxDetailsPageHeight()).Static(670)
+	widgets.NoScrollGroupWindow("tx-details-group-1", contentWindow.Window, func(window *widgets.Window) {
 		txDetailsTable1 := widgets.NewTable()
 		txDetailsTable1.AddRow(
 			widgets.NewLabelTableCell("Confirmations", "LC"),
@@ -78,26 +81,8 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 		)
 		txDetailsTable1.Render(window)
 
-		window.AddHorizontalSpace(30)
+		window.AddHorizontalSpace(10)
 
-		window.AddLabelWithFont("Inputs", "LC", styles.BoldPageContentFont)
-
-		txInputsTable := widgets.NewTable()
-		txInputsTable.AddRowWithFont(styles.NavFont,
-			widgets.NewLabelTableCell("Previous Outpoint", "LC"),
-			widgets.NewLabelTableCell("Amount", "LC"),
-		)
-
-		for _, input := range handler.selectedTxDetails.Inputs {
-			txInputsTable.AddRow(
-				widgets.NewLabelTableCell(input.PreviousTransactionHash, "LC"),
-				widgets.NewLabelTableCell(dcrutil.Amount(input.Amount).String(), "LC"),
-			)
-		}
-		txInputsTable.Render(window)
-	})
-
-	widgets.NoScrollGroupWindow("tx-details-col-2", contentWindow.Window, func(window *widgets.Window) {
 		txDetailsTable2 := widgets.NewTable()
 		txDetailsTable2.AddRow(
 			widgets.NewLabelTableCell("Amount", "LC"),
@@ -121,8 +106,24 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 		)
 		txDetailsTable2.Render(window)
 
-		window.AddHorizontalSpace(30)
+		window.AddHorizontalSpace(10)
+		window.AddLabelWithFont("Inputs", "LC", styles.BoldPageContentFont)
 
+		txInputsTable := widgets.NewTable()
+		txInputsTable.AddRowWithFont(styles.NavFont,
+			widgets.NewLabelTableCell("Previous Outpoint", "LC"),
+			widgets.NewLabelTableCell("Amount", "LC"),
+		)
+
+		for _, input := range handler.selectedTxDetails.Inputs {
+			txInputsTable.AddRow(
+				widgets.NewLabelTableCell(input.PreviousTransactionHash, "LC"),
+				widgets.NewLabelTableCell(dcrutil.Amount(input.Amount).String(), "LC"),
+			)
+		}
+		txInputsTable.Render(window)
+
+		window.AddHorizontalSpace(10)
 		window.AddLabelWithFont("Outputs", "LC", styles.BoldPageContentFont)
 
 		txOutputsTable := widgets.NewTable()
@@ -146,16 +147,10 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 }
 
 func (handler *HistoryHandler) calculateTxDetailsPageHeight() int {
-	firstSectionHeight := 240
-	outputsLen := len(handler.selectedTxDetails.Outputs)
-	inputsLen := len(handler.selectedTxDetails.Inputs)
+	firstSectionHeight := 460
+	lineHeight := 27
+	outputsHeight := len(handler.selectedTxDetails.Outputs) * lineHeight
+	inputsHeight := len(handler.selectedTxDetails.Inputs) * lineHeight
 
-	var secondSectionLines int
-	if outputsLen > inputsLen {
-		secondSectionLines = outputsLen
-	} else {
-		secondSectionLines = inputsLen
-	}
-
-	return firstSectionHeight + (secondSectionLines * 27)
+	return firstSectionHeight + outputsHeight + inputsHeight
 }

--- a/nuklear/pagehandlers/transaction_details.go
+++ b/nuklear/pagehandlers/transaction_details.go
@@ -2,6 +2,7 @@ package pagehandlers
 
 import (
 	"fmt"
+	"image/color"
 	"strconv"
 
 	"github.com/aarzilli/nucular"
@@ -53,10 +54,13 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 	}
 
 	var status string
+	var statusColor color.RGBA
 	if handler.selectedTxDetails.Confirmations >= 2 {
 		status = "Confirmed"
+		statusColor = styles.DecredGreenColor
 	} else {
 		status = "Unconfirmed"
+		statusColor = styles.DecredOrangeColor
 	}
 
 	// we create our tables here so that we are able to calculate our window height using table data
@@ -99,7 +103,7 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 	)
 	txDetailsTable.AddRow(
 		widgets.NewLabelTableCell("Status", "LC"),
-		widgets.NewLabelTableCell(status, "LC"),
+		widgets.NewColoredLabelTableCell(status, "LC", statusColor),
 	)
 	txDetailsTable.AddRow(
 		widgets.NewLabelTableCell("Date", "LC"),

--- a/nuklear/pagehandlers/transaction_details.go
+++ b/nuklear/pagehandlers/transaction_details.go
@@ -47,7 +47,7 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 	// Create row to hold tx details in 2 columns
 	// Each column will display data about the tx in a group window.
 	// Row height is calculated based on the max group items total height
-	contentWindow.Window.Row(handler.calculateTxDetailsPageHeight()).Static(670)
+	contentWindow.Window.Row(handler.calculateTxDetailsPageHeight()).Static(730)
 	widgets.NoScrollGroupWindow("tx-details-group-1", contentWindow.Window, func(window *widgets.Window) {
 		breadcrumb := []*widgets.Breadcrumb{
 			{
@@ -65,6 +65,13 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 		window.AddBreadcrumb(breadcrumb)
 		if handler.selectedTxHash == "" {
 			return
+		}
+
+		var status string
+		if handler.selectedTxDetails.Confirmations >= 2 {
+			status = "Confirmed"
+		} else {
+			status = "Unconfirmed"
 		}
 
 		txDetailsTable := widgets.NewTable()
@@ -105,7 +112,11 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 			widgets.NewLabelTableCell(dcrutil.Amount(handler.selectedTxDetails.FeeRate).String(), "LC"),
 		)
 		txDetailsTable.AddRow(
-			widgets.NewLabelTableCell("Time", "LC"),
+			widgets.NewLabelTableCell("Status", "LC"),
+			widgets.NewLabelTableCell(status, "LC"),
+		)
+		txDetailsTable.AddRow(
+			widgets.NewLabelTableCell("Date", "LC"),
 			widgets.NewLabelTableCell(fmt.Sprintf("%s UTC", handler.selectedTxDetails.LongTime), "LC"),
 		)
 		txDetailsTable.Render(window)
@@ -116,12 +127,14 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 		txInputsTable := widgets.NewTable()
 		txInputsTable.AddRowWithFont(styles.NavFont,
 			widgets.NewLabelTableCell("Previous Outpoint", "LC"),
+			widgets.NewLabelTableCell("Account", "LC"),
 			widgets.NewLabelTableCell("Amount", "LC"),
 		)
 
 		for _, input := range handler.selectedTxDetails.Inputs {
 			txInputsTable.AddRow(
 				widgets.NewLabelTableCell(input.PreviousTransactionHash, "LC"),
+				widgets.NewLabelTableCell(input.AccountName, "LC"),
 				widgets.NewLabelTableCell(dcrutil.Amount(input.Amount).String(), "LC"),
 			)
 		}

--- a/nuklear/pagehandlers/transaction_details.go
+++ b/nuklear/pagehandlers/transaction_details.go
@@ -53,13 +53,10 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 		return
 	}
 
-	var status string
 	var statusColor color.RGBA
-	if handler.selectedTxDetails.Confirmations >= 2 {
-		status = "Confirmed"
+	if handler.selectedTxDetails.Status == "Confirmed" {
 		statusColor = styles.DecredGreenColor
 	} else {
-		status = "Unconfirmed"
 		statusColor = styles.DecredOrangeColor
 	}
 
@@ -103,7 +100,7 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 	)
 	txDetailsTable.AddRow(
 		widgets.NewLabelTableCell("Status", "LC"),
-		widgets.NewColoredLabelTableCell(status, "LC", statusColor),
+		widgets.NewColoredLabelTableCell(handler.selectedTxDetails.Status, "LC", statusColor),
 	)
 	txDetailsTable.AddRow(
 		widgets.NewLabelTableCell("Date", "LC"),

--- a/nuklear/pagehandlers/transaction_details.go
+++ b/nuklear/pagehandlers/transaction_details.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"fmt"
-
 	"github.com/aarzilli/nucular"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/raedahgroup/godcr/nuklear/styles"
@@ -69,53 +67,48 @@ func (handler *HistoryHandler) displayTransactionDetails(contentWindow *widgets.
 			return
 		}
 
-		txDetailsTable1 := widgets.NewTable()
-		txDetailsTable1.AddRow(
+		txDetailsTable := widgets.NewTable()
+		txDetailsTable.AddRow(
 			widgets.NewLabelTableCell("Confirmations", "LC"),
 			widgets.NewLabelTableCell(strconv.Itoa(int(handler.selectedTxDetails.Confirmations)), "LC"),
 		)
-		txDetailsTable1.AddRow(
+		txDetailsTable.AddRow(
 			widgets.NewLabelTableCell("Hash", "LC"),
 			widgets.NewLabelTableCell(handler.selectedTxDetails.Hash, "LC"),
 		)
-		txDetailsTable1.AddRow(
+		txDetailsTable.AddRow(
 			widgets.NewLabelTableCell("Block Height", "LC"),
 			widgets.NewLabelTableCell(strconv.Itoa(int(handler.selectedTxDetails.BlockHeight)), "LC"),
 		)
-		txDetailsTable1.AddRow(
+		txDetailsTable.AddRow(
 			widgets.NewLabelTableCell("Direction", "LC"),
 			widgets.NewLabelTableCell(handler.selectedTxDetails.Direction.String(), "LC"),
 		)
-		txDetailsTable1.AddRow(
+		txDetailsTable.AddRow(
 			widgets.NewLabelTableCell("Type", "LC"),
 			widgets.NewLabelTableCell(handler.selectedTxDetails.Type, "LC"),
 		)
-		txDetailsTable1.Render(window)
-
-		window.AddHorizontalSpace(10)
-
-		txDetailsTable2 := widgets.NewTable()
-		txDetailsTable2.AddRow(
+		txDetailsTable.AddRow(
 			widgets.NewLabelTableCell("Amount", "LC"),
 			widgets.NewLabelTableCell(dcrutil.Amount(handler.selectedTxDetails.Amount).String(), "LC"),
 		)
-		txDetailsTable2.AddRow(
+		txDetailsTable.AddRow(
 			widgets.NewLabelTableCell("Size", "LC"),
 			widgets.NewLabelTableCell(strconv.Itoa(handler.selectedTxDetails.Size)+" Bytes", "LC"),
 		)
-		txDetailsTable2.AddRow(
+		txDetailsTable.AddRow(
 			widgets.NewLabelTableCell("Fee", "LC"),
 			widgets.NewLabelTableCell(dcrutil.Amount(handler.selectedTxDetails.Fee).String(), "LC"),
 		)
-		txDetailsTable2.AddRow(
+		txDetailsTable.AddRow(
 			widgets.NewLabelTableCell("Fee Rate", "LC"),
 			widgets.NewLabelTableCell(dcrutil.Amount(handler.selectedTxDetails.FeeRate).String(), "LC"),
 		)
-		txDetailsTable2.AddRow(
+		txDetailsTable.AddRow(
 			widgets.NewLabelTableCell("Time", "LC"),
 			widgets.NewLabelTableCell(fmt.Sprintf("%s UTC", handler.selectedTxDetails.LongTime), "LC"),
 		)
-		txDetailsTable2.Render(window)
+		txDetailsTable.Render(window)
 
 		window.AddHorizontalSpace(10)
 		window.AddLabelWithFont("Inputs", "LC", styles.BoldPageContentFont)

--- a/nuklear/styles/styles.go
+++ b/nuklear/styles/styles.go
@@ -77,9 +77,9 @@ func SetPageStyle(masterWindow nucular.MasterWindow) {
 
 	// style selectable labels (links)
 	currentStyle.Selectable.Padding = noPadding
-	currentStyle.Selectable.TextNormal = DecredDarkBlueColor
-	currentStyle.Selectable.TextHover = DecredLightBlueColor
-	currentStyle.Selectable.TextPressed = DecredLightBlueColor
+	currentStyle.Selectable.TextNormal = DecredLightBlueColor
+	currentStyle.Selectable.TextHover = DecredDarkBlueColor
+	currentStyle.Selectable.TextPressed = DecredDarkBlueColor
 	currentStyle.Selectable.Normal.Data.Color = WhiteColor
 	currentStyle.Selectable.Hover.Data.Color = WhiteColor
 	currentStyle.Selectable.Pressed.Data.Color = WhiteColor

--- a/nuklear/widgets/breadcrumb.go
+++ b/nuklear/widgets/breadcrumb.go
@@ -5,16 +5,16 @@ type Breadcrumb struct {
 	Action func(string, *Window)
 }
 
-func (window *Window) AddBreadcrumb(breadcrumb []*Breadcrumb) {
+func (window *Window) AddBreadcrumb(breadcrumbs []*Breadcrumb) {
 	tableCells := []TableCell{}
 
-	for index := range breadcrumb {
+	for index := range breadcrumbs {
 		var cell TableCell
-		isLastItem := index == len(breadcrumb)-1
+		isLastItem := breadcrumbs[index].Action == nil
 		if isLastItem {
-			cell = NewLabelTableCell(breadcrumb[index].Text, "LC")
+			cell = NewLabelTableCell(breadcrumbs[index].Text, "LC")
 		} else {
-			cell = NewLinkTableCell(breadcrumb[index].Text, "", breadcrumb[index].Action)
+			cell = NewLinkTableCell(breadcrumbs[index].Text, "", breadcrumbs[index].Action)
 		}
 		tableCells = append(tableCells, cell)
 		if !isLastItem {

--- a/nuklear/widgets/breadcrumb.go
+++ b/nuklear/widgets/breadcrumb.go
@@ -1,0 +1,28 @@
+package widgets
+
+type Breadcrumb struct {
+	Text   string
+	Action func(string, *Window)
+}
+
+func (window *Window) AddBreadcrumb(breadcrumb []*Breadcrumb) {
+	tableCells := []TableCell{}
+
+	for index := range breadcrumb {
+		var cell TableCell
+		isLastItem := index == len(breadcrumb)-1
+		if isLastItem {
+			cell = NewLabelTableCell(breadcrumb[index].Text, "LC")
+		} else {
+			cell = NewLinkTableCell(breadcrumb[index].Text, "", breadcrumb[index].Action)
+		}
+		tableCells = append(tableCells, cell)
+		if !isLastItem {
+			tableCells = append(tableCells, NewLabelTableCell("/", "LC"))
+		}
+	}
+
+	table := NewTable()
+	table.AddRow(tableCells...)
+	table.Render(window)
+}

--- a/nuklear/widgets/table.go
+++ b/nuklear/widgets/table.go
@@ -1,6 +1,9 @@
 package widgets
 
-const tableRowHeight = 25
+const (
+	TableRowHeight           = 27
+	estimatedTableRowPadding = 3
+)
 
 type Table struct {
 	rows []*TableRow
@@ -63,7 +66,7 @@ func (table *Table) Render(window *Window) {
 
 	// create row constructor for each row of items and call draw on the items
 	for _, row := range table.rows {
-		window.Row(tableRowHeight).Static(maxColumnWidths...)
+		window.Row(TableRowHeight).Static(maxColumnWidths...)
 		if row.isFontSet {
 			window.UseFontAndResetToPrevious(row.font, func() {
 				row.Render(window)
@@ -72,4 +75,8 @@ func (table *Table) Render(window *Window) {
 			row.Render(window)
 		}
 	}
+}
+
+func (table *Table) Height() int {
+	return len(table.rows) * (TableRowHeight + estimatedTableRowPadding)
 }


### PR DESCRIPTION
This changes the layout of the nuklear transaction details page to display transaction details using a single column instead of two columns. 

This fixes #335 

![Screenshot from 2019-04-25 15-34-42](https://user-images.githubusercontent.com/42093751/56744754-ff602580-6770-11e9-8248-f433cabb2ddc.png)
