### PR TITLE
Ensure wallet type

### DIFF
--- a/cli/walletloader/createwallet.go
+++ b/cli/walletloader/createwallet.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/hdkeychain"
 	"github.com/decred/dcrwallet/walletseed"
 	"github.com/raedahgroup/godcr/app/config"

--- a/cli/walletloader/createwallet.go
+++ b/cli/walletloader/createwallet.go
@@ -115,11 +115,6 @@ func prepareMiddlewareToCreateNewWallet(ctx context.Context, newWalletNetwork st
 
 	return dcrlibwallet.Connect(ctx, walletDbDir, newWalletNetwork)
 }
-func detectWalletType(wallet string) (walletType dcrlibwallet.DcrWalletLib, err error) {
-	wallet = dcrutil.AppDataDir(wallet, false)
-
-	return
-}
 
 // requestNewWalletPassphrase asks user to enter private passphrase for new wallet twice.
 // Prompt is repeated if both entered passphrases don't match.
@@ -142,6 +137,7 @@ func requestNewWalletPassphrase() (string, error) {
 		return passphrase, nil
 	}
 }
+
 func generateNewWalletSeedAndDisplay() (string, error) {
 	// generate seed
 	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)

--- a/cli/walletloader/createwallet.go
+++ b/cli/walletloader/createwallet.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/hdkeychain"
 	"github.com/decred/dcrwallet/walletseed"
 	"github.com/raedahgroup/godcr/app/config"
@@ -114,6 +115,11 @@ func prepareMiddlewareToCreateNewWallet(ctx context.Context, newWalletNetwork st
 
 	return dcrlibwallet.Connect(ctx, walletDbDir, newWalletNetwork)
 }
+func detectWalletType(wallet string) (walletType dcrlibwallet.DcrWalletLib, err error) {
+	wallet = dcrutil.AppDataDir(wallet, false)
+
+	return
+}
 
 // requestNewWalletPassphrase asks user to enter private passphrase for new wallet twice.
 // Prompt is repeated if both entered passphrases don't match.
@@ -136,7 +142,6 @@ func requestNewWalletPassphrase() (string, error) {
 		return passphrase, nil
 	}
 }
-
 func generateNewWalletSeedAndDisplay() (string, error) {
 	// generate seed
 	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)

--- a/cli/walletloader/detectwallets.go
+++ b/cli/walletloader/detectwallets.go
@@ -59,10 +59,9 @@ func findWalletsInDirectory(walletDir, walletSource string) (wallets []*WalletIn
 			strings.Index(dirName, "testnet") == -1 {
 			return utils.NetParams("testnet3")
 		} else if strings.Index(dirName, "simnet") == 0 ||
-			strings.Index(dirName, "simnet") == -1{
+			strings.Index(dirName, "simnet") == -1 {
 			return utils.NetParams("simnet")
 		}
-
 
 		return nil
 	}

--- a/cli/walletloader/detectwallets.go
+++ b/cli/walletloader/detectwallets.go
@@ -14,6 +14,7 @@ import (
 	"github.com/raedahgroup/godcr/app/config"
 	"github.com/raedahgroup/godcr/app/walletmediums/dcrlibwallet"
 	"github.com/raedahgroup/godcr/cli/termio/terminalprompt"
+	"github.com/decred/dcrd/chaincfg"
 )
 
 type WalletInfo struct {
@@ -52,16 +53,20 @@ func findWalletsInDirectory(walletDir, walletSource string) (wallets []*WalletIn
 		dirName := filepath.Base(walletDbDir)
 
 		// check if folder name starts with any of the supported nettypes
-		if strings.Index(dirName, "mainnet") == 0 ||
-			strings.Index(dirName, "mainnet") == -1 {
+		if strings.Index(dirName, "mainnet") == 0 {
 			return utils.NetParams("mainnet")
-		} else if strings.Index(dirName, "testnet3") == 0 ||
-			strings.Index(dirName, "testnet") == -1 {
+		} else if strings.Index(dirName, "mainnet") == -1 {
+			return nil
+		} else if strings.Index(dirName, "testnet3") == 0 {
 			return utils.NetParams("testnet3")
-		} else if strings.Index(dirName, "simnet") == 0 ||
-			strings.Index(dirName, "simnet") == -1 {
+		}else if strings.Index(dirName, "testnet") == -1 {
+			return nil
+		} else if strings.Index(dirName, "simnet") == 0 {
 			return utils.NetParams("simnet")
+		} else if strings.Index(dirName, "simnet") == -1 {
+			return nil
 		}
+
 
 		return nil
 	}

--- a/cli/walletloader/detectwallets.go
+++ b/cli/walletloader/detectwallets.go
@@ -52,14 +52,15 @@ func findWalletsInDirectory(walletDir, walletSource string) (wallets []*WalletIn
 		dirName := filepath.Base(walletDbDir)
 
 		// check if folder name starts with any of the supported nettypes
-		if strings.Index(dirName, "mainnet") == 0 {
+		if strings.Index(dirName, "mainnet") == 0 ||
+			strings.Index(dirName, "mainnet") == -1 {
 			return utils.NetParams("mainnet")
-		} else if strings.Index(dirName, "testnet3") == 0 {
+		} else if strings.Index(dirName, "testnet3") == 0 ||
+			strings.Index(dirName, "testnet") == -1 {
 			return utils.NetParams("testnet3")
-		} else if strings.Index(dirName, "simnet") == 0 {
+		} else if strings.Index(dirName, "simnet") == 0 ||
+			strings.Index(dirName, "simnet") == -1{
 			return utils.NetParams("simnet")
-		}else if strings.Index(dirName, "") == -1 {
-			return nil
 		}
 
 

--- a/cli/walletloader/detectwallets.go
+++ b/cli/walletloader/detectwallets.go
@@ -48,7 +48,7 @@ func findWalletsInDirectory(walletDir, walletSource string) (wallets []*WalletIn
 	// netType checks if the name of the directory where a wallet.db file was found is the name of a known/supported network type
 	// dcrwallet, decredition and dcrlibwallet place wallet db files in "mainnet" or "testnet3" directories
 	// returns nil if the directory used does not correspond to a known/supported network type
-	firstAddressChar := chaincfg.Params.NetworkAddressPrefix
+	firstAddressChar := chaincfg.Params{}.NetworkAddressPrefix
 
 	detectNetParams := func(path string) *netparams.Params {
 		//walletDbDir := filepath.Dir(path)

--- a/cli/walletloader/detectwallets.go
+++ b/cli/walletloader/detectwallets.go
@@ -48,28 +48,36 @@ func findWalletsInDirectory(walletDir, walletSource string) (wallets []*WalletIn
 	// netType checks if the name of the directory where a wallet.db file was found is the name of a known/supported network type
 	// dcrwallet, decredition and dcrlibwallet place wallet db files in "mainnet" or "testnet3" directories
 	// returns nil if the directory used does not correspond to a known/supported network type
+	firstAddressChar := chaincfg.Params.NetworkAddressPrefix
+
 	detectNetParams := func(path string) *netparams.Params {
-		walletDbDir := filepath.Dir(path)
-		dirName := filepath.Base(walletDbDir)
+		//walletDbDir := filepath.Dir(path)
+		//dirName := filepath.Base(walletDbDir)
 
 		// check if folder name starts with any of the supported nettypes
-		if strings.Index(dirName, "mainnet") == 0 {
+		//if strings.Index(firstAddressChar, "mainnet") == 0 {
+		//	return utils.NetParams("mainnet")
+		//} else if strings.Index(firstAddressChar, "testnet3") == 0 {
+		//	return utils.NetParams("testnet3")
+		//} else if strings.Index(firstAddressChar, "simnet") == 0 {
+		//	return utils.NetParams("simnet")
+		//}
+
+		//check if the prefix of the generated address is simulacrum
+		//to the first index of the supported nettypes and returns the
+		//appropriate nettype found in the wallet directory
+		if firstAddressChar == "D" {
 			return utils.NetParams("mainnet")
-		} else if strings.Index(dirName, "mainnet") == -1 {
-			return nil
-		} else if strings.Index(dirName, "testnet3") == 0 {
+		}else if firstAddressChar == "T" {
 			return utils.NetParams("testnet3")
-		}else if strings.Index(dirName, "testnet") == -1 {
-			return nil
-		} else if strings.Index(dirName, "simnet") == 0 {
+		}else if firstAddressChar == "S" {
 			return utils.NetParams("simnet")
-		} else if strings.Index(dirName, "simnet") == -1 {
-			return nil
 		}
 
 
 		return nil
-	}
+	} 
+	
 
 	err = filepath.Walk(walletDir, func(path string, file os.FileInfo, err error) error {
 		if err != nil || file.IsDir() || file.Name() != app.WalletDbFileName {
@@ -161,6 +169,7 @@ func listWalletsForSelection(ctx context.Context, cfg *config.Config, allDetecte
 	// user chose to create new wallet
 	return createWallet(ctx, cfg)
 }
+
 
 func promptToSaveDefaultWallet(walletDbDir string) {
 	prompt := "Would you like to use this wallet by default?"

--- a/cli/walletloader/detectwallets.go
+++ b/cli/walletloader/detectwallets.go
@@ -64,7 +64,7 @@ func findWalletsInDirectory(walletDir, walletSource string) (wallets []*WalletIn
 	}
 
 	err = filepath.Walk(walletDir, func(path string, file os.FileInfo, err error) error {
-		if err != nil || file.IsDir() || file.Name() != app.WalletDbFileName {
+		if err != nil || file.Name() != app.WalletDbFileName {
 			return nil
 		}
 

--- a/cli/walletloader/detectwallets.go
+++ b/cli/walletloader/detectwallets.go
@@ -58,13 +58,16 @@ func findWalletsInDirectory(walletDir, walletSource string) (wallets []*WalletIn
 			return utils.NetParams("testnet3")
 		} else if strings.Index(dirName, "simnet") == 0 {
 			return utils.NetParams("simnet")
+		}else if strings.Index(dirName, "") == -1 {
+			return nil
 		}
+
 
 		return nil
 	}
 
 	err = filepath.Walk(walletDir, func(path string, file os.FileInfo, err error) error {
-		if err != nil || file.Name() != app.WalletDbFileName {
+		if err != nil || file.IsDir() || file.Name() != app.WalletDbFileName {
 			return nil
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/dcrwallet v1.2.3-0.20181120205657-8690f1096aa7
 	github.com/decred/dcrwallet/rpc/walletrpc v1.0.1-0.20181109211527-ca582da21c08
+	github.com/decred/dcrwallet/wallet v1.3.0
 	github.com/decred/dcrwallet/walletseed v1.0.1
 	github.com/decred/slog v1.0.0
 	github.com/gdamore/tcell v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	fyne.io/fyne v0.0.0-20190411071008-b3687258b083
 	github.com/aarzilli/nucular v0.0.0-20190403084742-0071461892e4
 	github.com/atotto/clipboard v0.1.2
+	github.com/decred/dcrd/chaincfg v1.3.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrutil v1.2.0
 	github.com/decred/dcrd/hdkeychain v1.1.1

--- a/terminal/pages/rootpage.go
+++ b/terminal/pages/rootpage.go
@@ -104,7 +104,7 @@ func RootPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware
 	})
 
 	tviewApp.QueueUpdateDraw(func() {
-		displayPage(LaunchSyncPage(tviewApp, walletMiddleware, displayPage, hintTextView,  tviewApp.SetFocus, clearFocus))
+		displayPage(LaunchSyncPage(tviewApp, walletMiddleware, displayPage, hintTextView, tviewApp.SetFocus, clearFocus))
 	})
 
 	return gridLayout

--- a/terminal/pages/sync.go
+++ b/terminal/pages/sync.go
@@ -15,7 +15,7 @@ import (
 func LaunchSyncPage(tviewApp *tview.Application, walletMiddleware app.WalletMiddleware, displayPage func(tview.Primitive), hintTextView *primitives.TextView, setFocus func(p tview.Primitive) *tview.Application, clearFocus func()) tview.Primitive {
 	syncPage := tview.NewFlex().SetDirection(tview.FlexRow)
 
-	// page title 
+	// page title
 	syncPage.AddItem(primitives.NewCenterAlignedTextView("Synchronizing"), 1, 0, false)
 
 	errorTextView := primitives.WordWrappedTextView("")
@@ -68,8 +68,8 @@ func LaunchSyncPage(tviewApp *tview.Application, walletMiddleware app.WalletMidd
 		if event.Key() == tcell.KeyEsc {
 			if cancelTriggered {
 				clearFocus()
-			displayPage(overviewPage(walletMiddleware, hintTextView, tviewApp, clearFocus))
-		} else {
+				displayPage(overviewPage(walletMiddleware, hintTextView, tviewApp, clearFocus))
+			} else {
 				cancelTriggered = true
 				// remove cancel trigger after 1 second if user does not press escape again within that time
 				go func() {


### PR DESCRIPTION
The condition set to ascertain if the folder name(wallet directory) starts with any of the supported nettypes(mainnet, etc) did not include the condition and expected behavior if the nettype found in the directory folder was the same as the folder name.

The pull request was to fix that; the condition and expected behavior.
