### PR TITLE
Terminal receive page generate new address

### DIFF
--- a/terminal/pages/receive.go
+++ b/terminal/pages/receive.go
@@ -19,10 +19,10 @@ func receivePage(wallet walletcore.Wallet, hintTextView *primitives.TextView, se
 		SetTextColor(helpers.HintTextColor)
 	body.AddItem(receivingDecredHintTextView, 2, 1, false)
 
-	generateAdressFunc := func (formButton tview.Primitive) {
+	generateAdressFunc := func(formButton tview.Primitive) {
 		newAdd := tview.NewFlex().
-		AddItem(primitives.NewLeftAlignedTextView("You can also manually generate a").SetTextColor(helpers.HintTextColor), 33, 0, false).
-		AddItem(formButton, 0, 1, false)
+			AddItem(primitives.NewLeftAlignedTextView("You can also manually generate a").SetTextColor(helpers.HintTextColor), 33, 0, false).
+			AddItem(formButton, 0, 1, false)
 		body.AddItem(newAdd, 3, 1, false)
 	}
 
@@ -140,12 +140,12 @@ func receivePage(wallet walletcore.Wallet, hintTextView *primitives.TextView, se
 		formButton.AddButton("New Address", func() {
 			generateAndDisplayAddress(accountNumber, true)
 		})
-		
+
 		generateAdressFunc(formButton)
 
 		body.AddItem(formDropdown, 2, 0, true)
 		hintTextView.SetText("TIP: Select Prefered Account and hit ENTER to generate Address, \nMove around with TAB, ESC to return to navigation menu")
-	
+
 		formDropdown.GetFormItemBox(0).SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 			if event.Key() == tcell.KeyTab {
 				setFocus(formButton)
@@ -164,7 +164,7 @@ func receivePage(wallet walletcore.Wallet, hintTextView *primitives.TextView, se
 			return event
 		})
 	}
-	
+
 	// always generate and display address for the first account, even if there are multiple accounts
 	generateAndDisplayAddress(accounts[0].Number, false)
 

--- a/terminal/pages/receive.go
+++ b/terminal/pages/receive.go
@@ -20,10 +20,10 @@ func receivePage(wallet walletcore.Wallet, hintTextView *primitives.TextView, se
 	body.AddItem(receivingDecredHintTextView, 2, 1, false)
 
 	generateAdressFunc := func(formButton tview.Primitive) {
-		newAdd := tview.NewFlex().
+		newAddressFlex := tview.NewFlex().
 			AddItem(primitives.NewLeftAlignedTextView("You can also manually generate a").SetTextColor(helpers.HintTextColor), 33, 0, false).
 			AddItem(formButton, 0, 1, false)
-		body.AddItem(newAdd, 3, 1, false)
+		body.AddItem(newAddressFlex, 3, 1, false)
 	}
 
 	accounts, err := wallet.AccountsOverview(walletcore.DefaultRequiredConfirmations)
@@ -92,7 +92,7 @@ func receivePage(wallet walletcore.Wallet, hintTextView *primitives.TextView, se
 				clearFocus()
 			}
 		})
-		formButton.AddButton("New Address", func() {
+		formButton.AddButton("NEW ADDRESS.", func() {
 			generateAndDisplayAddress(accounts[0].Number, true)
 		})
 
@@ -137,7 +137,7 @@ func receivePage(wallet walletcore.Wallet, hintTextView *primitives.TextView, se
 			generateAndDisplayAddress(accountNumber, false)
 		})
 
-		formButton.AddButton("New Address", func() {
+		formButton.AddButton("NEW ADDRESS.", func() {
 			generateAndDisplayAddress(accountNumber, true)
 		})
 

--- a/terminal/primitives/form.go
+++ b/terminal/primitives/form.go
@@ -135,6 +135,14 @@ func (f *Form) SetButtonTextColor(color tcell.Color) *Form {
 	return f
 }
 
+// SetItemPadding sets the number of empty rows between form items for vertical
+// layouts and the number of empty cells between form items for horizontal
+// layouts.
+func (f *Form) SetItemPadding(padding int) *Form {
+	f.itemPadding = padding
+	return f
+}
+
 // AddInputField adds an input field to the form. It has a label, an optional
 // initial value, a field width (a value of 0 extends it as far as possible),
 // an optional accept function to validate the item's value (set to nil to


### PR DESCRIPTION
fixes #285 and #373
Moved generated address to the top of qrcode, added generate new account feature to receive page
![image](https://user-images.githubusercontent.com/27733432/59091993-693f2380-8908-11e9-9b4f-886b9c8c247f.png)

