### PR TITLE
add option to sync with dcrd full node

### DIFF
--- a/app/config/config-file.go
+++ b/app/config/config-file.go
@@ -20,9 +20,18 @@ type ConfFileOptions struct {
 	NoWalletRPCTLS   bool   `long:"nowalletrpctls" description:"Disable TLS when connecting to dcrwallet daemon via RPC."`
 	HTTPHost         string `long:"httphost" description:"HTTP server host address or IP when running godcr in http mode."`
 	HTTPPort         string `long:"httpport" description:"HTTP server port when running godcr in http mode."`
-	DebugLevel       string `long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
+	DebugLevel       string `long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}."`
+	UseDcrdBackend   bool   `long:"usedcrdbackend" description:"Connect to dcrd for syncing."`
 
-	Settings `group:"Settings"`
+	DcrdRpcConfig `group:"Dcrd Connection Options"`
+	Settings      `group:"Settings"`
+}
+
+type DcrdRpcConfig struct {
+	DcrdHost     string `long:"dcrdhost" description:"Hostname/IP for dcrd server"`
+	DcrdUser     string `long:"dcrduser" description:"Username for dcrd server"`
+	DcrdPassword string `long:"dcrdpassword" description:"Password for dcrd server"`
+	DcrdCert     string `long:"dcrdcert" description:"Certificate path for dcrd server"`
 }
 
 type Settings struct {

--- a/app/walletmediums/dcrwalletrpc/walletloader.go
+++ b/app/walletmediums/dcrwalletrpc/walletloader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/decred/dcrwallet/walletseed"
 	"github.com/raedahgroup/dcrlibwallet"
 	"github.com/raedahgroup/dcrlibwallet/defaultsynclistener"
+	"github.com/raedahgroup/godcr/app/config"
 	"github.com/raedahgroup/godcr/app/walletcore"
 )
 
@@ -55,7 +56,7 @@ func (c *WalletRPCClient) IsWalletOpen() bool {
 	return c.walletOpen
 }
 
-func (c *WalletRPCClient) SyncBlockChain(showLog bool, syncProgressUpdated func(*defaultsynclistener.ProgressReport)) {
+func (c *WalletRPCClient) SpvSync(showLog bool, syncProgressUpdated func(*defaultsynclistener.ProgressReport)) {
 	ctx := context.Background() // todo use a cancelable ctx
 
 	getBestBlock := func() int32 {
@@ -142,6 +143,10 @@ func (c *WalletRPCClient) SyncBlockChain(showLog bool, syncProgressUpdated func(
 			}
 		}
 	}()
+}
+
+func (c *WalletRPCClient) RpcSync(showLog bool, dcrdConfig config.DcrdRpcConfig, syncProgressUpdated func(*defaultsynclistener.ProgressReport)) {
+	fmt.Println("rpc sync not yet implemented")
 }
 
 func (c *WalletRPCClient) RescanBlockChain() error {

--- a/app/walletmiddleware.go
+++ b/app/walletmiddleware.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"github.com/raedahgroup/dcrlibwallet/defaultsynclistener"
+	"github.com/raedahgroup/godcr/app/config"
 	"github.com/raedahgroup/godcr/app/walletcore"
 )
 
@@ -16,8 +17,12 @@ type WalletMiddleware interface {
 
 	IsWalletOpen() bool
 
-	SyncBlockChain(showLog bool, syncProgressUpdated func(*defaultsynclistener.ProgressReport))
+	SpvSync(showLog bool, syncProgressUpdated func(*defaultsynclistener.ProgressReport))
 
+	// todo implement for dcrwallet rpc connections
+	RpcSync(showLog bool, dcrdConfig config.DcrdRpcConfig, syncProgressUpdated func(*defaultsynclistener.ProgressReport))
+
+	// todo should introduce SpvRescan and RpcRescan
 	RescanBlockChain() error
 
 	WalletConnectionInfo() (info walletcore.ConnectionInfo, err error)

--- a/cli/walletloader/sync.go
+++ b/cli/walletloader/sync.go
@@ -37,7 +37,7 @@ func SyncBlockChain(ctx context.Context, walletMiddleware app.WalletMiddleware) 
 	}
 
 	fmt.Println("Sync started.")
-	walletMiddleware.SyncBlockChain(true, processSyncUpdates)
+	walletMiddleware.SpvSync(true, processSyncUpdates)
 
 	// wait for context cancel or sync done trigger before exiting function
 	select {

--- a/fyne/fyne.go
+++ b/fyne/fyne.go
@@ -6,14 +6,15 @@ import (
 	"fyne.io/fyne"
 	"fyne.io/fyne/app"
 	godcrApp "github.com/raedahgroup/godcr/app"
+	"github.com/raedahgroup/godcr/app/config"
 	"github.com/raedahgroup/godcr/fyne/pages"
 )
 
 //todo: implement better error logger, probably log to a file
-func LaunchFyne(ctx context.Context, walletMiddleware godcrApp.WalletMiddleware) {
+func LaunchFyne(ctx context.Context, walletMiddleware godcrApp.WalletMiddleware, appConfig *config.Config) {
 	fyneApp := app.New()
 	window := fyneApp.NewWindow(godcrApp.DisplayName)
-	sync := pages.ShowSyncWindow(ctx, walletMiddleware, window, fyneApp)
+	sync := pages.ShowSyncWindow(ctx, walletMiddleware, appConfig.UseDcrdBackend, appConfig.DcrdRpcConfig, window, fyneApp)
 	window.SetContent(sync)
 	window.Resize(fyne.NewSize(1000, 500))
 	window.CenterOnScreen()

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 	case "nuklear":
 		enterNuklearMode(ctx, walletMiddleware)
 	case "fyne":
-		enterFyneMode(ctx, walletMiddleware)
+		enterFyneMode(ctx, walletMiddleware, appConfig)
 	case "terminal":
 		enterTerminalMode(ctx, walletMiddleware, appConfig.Settings)
 	}
@@ -259,9 +259,9 @@ func enterNuklearMode(ctx context.Context, walletMiddleware app.WalletMiddleware
 	beginShutdown <- true
 }
 
-func enterFyneMode(ctx context.Context, walletMiddleware app.WalletMiddleware) {
+func enterFyneMode(ctx context.Context, walletMiddleware app.WalletMiddleware, appConfig *config.Config) {
 	logInfo("Launching desktop app with fyne")
-	fyne.LaunchFyne(ctx, walletMiddleware)
+	fyne.LaunchFyne(ctx, walletMiddleware, appConfig)
 	beginShutdown <- true
 }
 

--- a/nuklear/syncer.go
+++ b/nuklear/syncer.go
@@ -35,7 +35,7 @@ func NewSyncer() *Syncer {
 
 func (s *Syncer) startSyncing(walletMiddleware app.WalletMiddleware, masterWindow nucular.MasterWindow) {
 	// begin block chain sync now so that when `Render` is called shortly after this, there'd be a report to display
-	walletMiddleware.SyncBlockChain(false, func(report *defaultsynclistener.ProgressReport) {
+	walletMiddleware.SpvSync(false, func(report *defaultsynclistener.ProgressReport) {
 		progressReport := report.Read()
 
 		s.status = progressReport.Status

--- a/terminal/pages/sync.go
+++ b/terminal/pages/sync.go
@@ -90,7 +90,7 @@ func LaunchSyncPage(tviewApp *tview.Application, walletMiddleware app.WalletMidd
 
 func startSync(walletMiddleware app.WalletMiddleware, updateStatus func([]string), handleError func(string), afterSyncing func()) {
 	var isFirstSyncCompleted = true
-	walletMiddleware.SyncBlockChain(false, func(report *defaultsynclistener.ProgressReport) {
+	walletMiddleware.SpvSync(false, func(report *defaultsynclistener.ProgressReport) {
 		progressReport := report.Read()
 
 		if progressReport.Status == defaultsynclistener.SyncStatusSuccess {

--- a/web/routes/walletloader.go
+++ b/web/routes/walletloader.go
@@ -69,7 +69,7 @@ func (routes *Routes) walletLoaderFn(next http.Handler) http.Handler {
 }
 
 func (routes *Routes) syncBlockChain() {
-	routes.walletMiddleware.SyncBlockChain(false, func(report *defaultsynclistener.ProgressReport) {
+	routes.walletMiddleware.SpvSync(false, func(report *defaultsynclistener.ProgressReport) {
 		routes.syncProgressReport = report
 		routes.sendWsSyncProgress()
 		routes.sendWsConnectionInfoUpdate()


### PR DESCRIPTION
Add `usedcrdbackend` config flag and `DcrdRpcConfig` config options.

If `usedcrdbackend=true` and `DcrdRpcConfig` config options are set, launching fyne on godcr connects to dcrd using the provided information to keep the wallet synced.

Other interfaces do not yet work with the new options and continue to use spv mode always.
