### PR TITLE
Account page (with fyne library)

### DIFF
--- a/fyne/pages/accounts.go
+++ b/fyne/pages/accounts.go
@@ -1,0 +1,29 @@
+// Package pages contains implementations of the various pages that
+// can be viewed on the desktop GUI when using the "fyne" library.
+//
+// This file contains the implementation of the accounts overview page.
+package pages
+
+import (
+	"fmt"
+	"fyne.io/fyne"
+	"fyne.io/fyne/widget"
+	"github.com/raedahgroup/godcr/app"
+	"github.com/raedahgroup/godcr/app/walletcore"
+	"github.com/raedahgroup/godcr/fyne/log"
+)
+
+func accountsPage(wallet app.WalletMiddleware) fyne.CanvasObject {
+	accounts, err := wallet.AccountsOverview(walletcore.DefaultRequiredConfirmations)
+	if err != nil {
+		log.Error(err.Error())
+		return widget.NewLabel(fmt.Sprintf("Unable to retrieve accounts information: %s", err))
+	}
+	accountsGroup := widget.NewGroup("Accounts")
+	for _, account := range accounts {
+		accountName := widget.NewLabel(account.Name)
+		accountBalance := widget.NewLabel(account.Balance.String())
+		accountsGroup.Append(widget.NewVBox(widget.NewHBox(accountName, accountBalance)))
+	}
+	return accountsGroup
+}

--- a/fyne/pages/accounts.go
+++ b/fyne/pages/accounts.go
@@ -7,11 +7,16 @@ package pages
 import (
 	"fmt"
 	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/layout"
 	"fyne.io/fyne/widget"
 	"github.com/raedahgroup/godcr/app"
 	"github.com/raedahgroup/godcr/app/walletcore"
 	"github.com/raedahgroup/godcr/fyne/log"
+	"github.com/raedahgroup/godcr/fyne/widgets"
 )
+
+const defaultItemsSpacing = 10
 
 func accountsPage(wallet app.WalletMiddleware) fyne.CanvasObject {
 	accounts, err := wallet.AccountsOverview(walletcore.DefaultRequiredConfirmations)
@@ -19,11 +24,67 @@ func accountsPage(wallet app.WalletMiddleware) fyne.CanvasObject {
 		log.Error(err.Error())
 		return widget.NewLabel(fmt.Sprintf("Unable to retrieve accounts information: %s", err))
 	}
-	accountsGroup := widget.NewGroup("Accounts")
+	netType := wallet.NetType()
+	pageTitle := widget.NewLabelWithStyle("Accounts", fyne.TextAlignLeading, fyne.TextStyle{Bold:true, Italic:true})
+	pageBox := widget.NewVBox(pageTitle)
 	for _, account := range accounts {
-		accountName := widget.NewLabel(account.Name)
-		accountBalance := widget.NewLabel(account.Balance.String())
-		accountsGroup.Append(widget.NewVBox(widget.NewHBox(accountName, accountBalance)))
+		pageBox.Append(widgets.NewVSpacer(defaultItemsSpacing))
+		hSpace := widgets.NewHSpacer(defaultItemsSpacing)
+		detailSection := widget.NewHBox(hSpace, createDetailSection(account, netType))
+		toggleButton := createToggleButton(detailSection)
+		overviewSection := widget.NewHBox(toggleButton, createOverviewSection(account))
+		pageBox.Append(widget.NewVBox(overviewSection, detailSection))
 	}
-	return accountsGroup
+	pageLeftMargin := widgets.NewHSpacer(defaultItemsSpacing)
+	return widget.NewHBox(pageLeftMargin, pageBox)
+}
+
+func createOverviewSection(account *walletcore.Account) fyne.CanvasObject {
+	accountName := widget.NewLabel(account.Name)
+	accountBalance := widget.NewLabelWithStyle(account.Balance.String(), fyne.TextAlignTrailing, fyne.TextStyle{})
+	return widget.NewHBox(accountName, layout.NewSpacer(), accountBalance)
+}
+
+func createDetailSection(account *walletcore.Account, netType string) fyne.CanvasObject {
+	properties := widget.NewHBox(widget.NewLabelWithStyle("Properties", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}))
+	hSpace := widgets.NewHSpacer(defaultItemsSpacing)
+	accountNumber := widget.NewHBox(
+		widget.NewLabel("Account number"),
+		layout.NewSpacer(),
+		widget.NewLabel(fmt.Sprintf("%d", account.Number)))
+	hdPath := walletcore.MainnetHDPath
+	if netType == "testnet3" {
+		hdPath = walletcore.TestnetHDPath
+	}
+	hdPathBox := widget.NewHBox(widget.NewLabel("HD Path"), layout.NewSpacer(), widget.NewLabel(hdPath))
+	keysText := fmt.Sprintf(
+		"%d external, %d internal, %d imported",
+		account.ExternalKeyCount, account.InternalKeyCount, account.ImportedKeyCount)
+	keys := widget.NewHBox(widget.NewLabel("Keys"), layout.NewSpacer(), widget.NewLabel(keysText))
+	detailsBox := widget.NewVBox(properties, widget.NewHBox(hSpace, widget.NewVBox(accountNumber, hdPathBox, keys)))
+	return detailsBox
+}
+
+func createToggleButton(target fyne.CanvasObject) *widget.Button {
+	button := widget.Button{}
+	setButtonStyle := func() {
+		if target.Visible() {
+			button.SetText("-")
+			button.Style = widget.PrimaryButton
+		} else {
+			button.SetText("+")
+			button.Style = widget.DefaultButton
+		}
+	}
+	setButtonStyle()
+	button.OnTapped = func() {
+		if target.Visible() {
+			target.Hide()
+		} else {
+			target.Show()
+		}
+		setButtonStyle()
+		canvas.Refresh(&button)
+	}
+	return &button
 }

--- a/fyne/pages/accounts.go
+++ b/fyne/pages/accounts.go
@@ -41,8 +41,9 @@ func accountsPage(wallet app.WalletMiddleware) fyne.CanvasObject {
 
 func createOverviewSection(account *walletcore.Account) fyne.CanvasObject {
 	accountName := widget.NewLabel(account.Name)
-	accountBalance := widget.NewLabelWithStyle(account.Balance.String(), fyne.TextAlignTrailing, fyne.TextStyle{})
-	return widget.NewHBox(accountName, layout.NewSpacer(), accountBalance)
+	totalBalance := widget.NewLabel(fmt.Sprintf("Total balance: %s", account.Balance.Total))
+	spendableBalance := widget.NewLabel(fmt.Sprintf("Spendable balance: %s", account.Balance.Spendable))
+	return widget.NewHBox(accountName, layout.NewSpacer(), totalBalance, spendableBalance)
 }
 
 func createDetailSection(account *walletcore.Account, netType string) fyne.CanvasObject {

--- a/fyne/pages/accounts.go
+++ b/fyne/pages/accounts.go
@@ -7,7 +7,6 @@ package pages
 import (
 	"fmt"
 	"fyne.io/fyne"
-	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/layout"
 	"fyne.io/fyne/widget"
 	"github.com/raedahgroup/godcr/app"
@@ -25,18 +24,82 @@ func accountsPage(wallet app.WalletMiddleware) fyne.CanvasObject {
 		return widget.NewLabel(fmt.Sprintf("Unable to retrieve accounts information: %s", err))
 	}
 	netType := wallet.NetType()
-	pageTitle := widget.NewLabelWithStyle("Accounts", fyne.TextAlignLeading, fyne.TextStyle{Bold:true, Italic:true})
-	pageBox := widget.NewVBox(pageTitle)
+	pageTitle := widget.NewLabelWithStyle("Accounts", fyne.TextAlignLeading, fyne.TextStyle{Bold: true, Italic: true})
+	accountsBox := widget.NewVBox(pageTitle)
 	for _, account := range accounts {
-		pageBox.Append(widgets.NewVSpacer(defaultItemsSpacing))
+		accountsBox.Append(widgets.NewVSpacer(defaultItemsSpacing))
 		hSpace := widgets.NewHSpacer(defaultItemsSpacing)
 		detailSection := widget.NewHBox(hSpace, createDetailSection(account, netType))
 		toggleButton := createToggleButton(detailSection)
 		overviewSection := widget.NewHBox(toggleButton, createOverviewSection(account))
-		pageBox.Append(widget.NewVBox(overviewSection, detailSection))
+		accountsBox.Append(widget.NewVBox(overviewSection, detailSection))
 	}
+	addAccountForm := createAddAccountForm(wallet)
+	addAccountButton := createAddAccountButton(addAccountForm)
 	pageLeftMargin := widgets.NewHSpacer(defaultItemsSpacing)
-	return widget.NewHBox(pageLeftMargin, pageBox)
+	return widget.NewHBox(
+		pageLeftMargin,
+		accountsBox,
+		pageLeftMargin,
+		widget.NewVBox(widget.NewHBox(addAccountButton, layout.NewSpacer()), addAccountForm),
+	)
+}
+
+func toggleCanvasObjectVisibility(target fyne.CanvasObject) {
+	if target.Visible() {
+		target.Hide()
+	} else {
+		target.Show()
+	}
+}
+
+func createAddAccountButton(form fyne.CanvasObject) fyne.CanvasObject {
+	return &widget.Button{
+		Text:  "Add account",
+		Style: widget.PrimaryButton,
+		OnTapped: func() {
+			toggleCanvasObjectVisibility(form)
+		},
+	}
+}
+
+func createAddAccountForm(wallet walletcore.Wallet) fyne.CanvasObject {
+	accountNameEntry := &widget.Entry{
+		PlaceHolder: "Account name",
+	}
+	accountName := &widget.FormItem{
+		Text:   "Account name",
+		Widget: accountNameEntry,
+	}
+	walletPassphraseEntry := &widget.Entry{
+		PlaceHolder: "Wallet passphrase",
+		Password:    true,
+	}
+	walletPassphrase := &widget.FormItem{
+		Text:   "Wallet passphrase",
+		Widget: walletPassphraseEntry,
+	}
+	errorDisplay := widget.NewLabel("")
+	form := &widget.Form{
+		Items: []*widget.FormItem{accountName, walletPassphrase},
+	}
+	resetForm := func() {
+		accountNameEntry.SetText("")
+		walletPassphraseEntry.SetText("")
+		errorDisplay.SetText("")
+		errorDisplay.Hide()
+	}
+	form.OnCancel = resetForm
+	form.OnSubmit = func() {
+		_, err := wallet.NextAccount(accountNameEntry.Text, walletPassphraseEntry.Text)
+		if err != nil {
+			errorDisplay.SetText(fmt.Sprintf("Failed to create account. Reason: %s", err))
+			errorDisplay.Show()
+		} else {
+			resetForm()
+		}
+	}
+	return widget.NewVBox(form, errorDisplay)
 }
 
 func createOverviewSection(account *walletcore.Account) fyne.CanvasObject {
@@ -79,13 +142,8 @@ func createToggleButton(target fyne.CanvasObject) *widget.Button {
 	}
 	setButtonStyle()
 	button.OnTapped = func() {
-		if target.Visible() {
-			target.Hide()
-		} else {
-			target.Show()
-		}
+		toggleCanvasObjectVisibility(target)
 		setButtonStyle()
-		canvas.Refresh(&button)
 	}
 	return &button
 }

--- a/fyne/pages/menu.go
+++ b/fyne/pages/menu.go
@@ -68,7 +68,7 @@ func menuPage(ctx context.Context, wallet godcrApp.WalletMiddleware, fyneApp fyn
 		widget.NewTabItemWithIcon("History", fyne.NewStaticResource("History", historyFile), pageNotImplemented()),
 		widget.NewTabItemWithIcon("Send", fyne.NewStaticResource("Send", sendFile), pageNotImplemented()),
 		widget.NewTabItemWithIcon("Receive", fyne.NewStaticResource("Receive", receiveFile), receivePage(wallet, window)),
-		widget.NewTabItemWithIcon("Accounts", fyne.NewStaticResource("Accounts", accountsFile), pageNotImplemented()),
+		widget.NewTabItemWithIcon("Accounts", fyne.NewStaticResource("Accounts", accountsFile), accountsPage(wallet)),
 		widget.NewTabItemWithIcon("Staking", fyne.NewStaticResource("Staking", stakingFile), stakingPage(wallet)),
 		widget.NewTabItemWithIcon("More", fyne.NewStaticResource("More", moreFile), morePage(wallet, fyneApp)),
 		widget.NewTabItemWithIcon("Exit", fyne.NewStaticResource("Exit", exitFile), exit(ctx, fyneApp, window)))

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 fyne.io/fyne v1.1.0 h1:gQHhhS3u4uvjyP+LPU7gCj39gdO7czZ/ahhWQXwZlIk=
 fyne.io/fyne v1.1.0/go.mod h1:mz0CvQX1ACEjiDGpSH3D8Qf9yHq8dfYA039kG7p8ZhQ=
+fyne.io/fyne v1.1.1 h1:vmeT7lqdho+Upt/PWuDInj8xAkNAaZC/rbtr3goJczY=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 h1:HD8gA2tkByhMAwYaFAX9w2l7vxvBQ5NMoxDrkhqhtn4=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
This pull request implements the accounts page using the `fyne` library.
The page displays the list of accounts available, together with the accounts' balances.
Beside each account name, a toggle button is displayed. Clicking it will hide/show more information about the account.

The target functionality is that available in the mobile app, as seen in the following screenshots. Controls for changing account settings (i.e., setting an account as the default account, or hiding an account from the UI) will be done in another PR.

<img alt="Mobile screenshot with account details collapsed" src="https://user-images.githubusercontent.com/20553476/63523329-e0d92380-c4f1-11e9-81f6-317c992b1c3f.jpg" width="50%" height="50%" />

<img alt="Mobile screenshot with account details expanded" src="https://user-images.githubusercontent.com/20553476/63523343-e33b7d80-c4f1-11e9-97d0-bf6721db9c4f.jpg" width="50%" height="50%" />

The current functionality is as shown in the screenshot below.

![Desktop screenshot with the fyne library](https://user-images.githubusercontent.com/20553476/63643121-0c126d00-c6c2-11e9-82c8-fd70fc8816ff.png)