### PR TITLE
Add live data to wallet sync details

### DIFF
--- a/fyne/handlers/overview.go
+++ b/fyne/handlers/overview.go
@@ -1,0 +1,246 @@
+package handlers
+
+import (
+	"fmt"
+	"image/color"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/widget"
+
+	"github.com/decred/dcrd/dcrutil"
+	"github.com/raedahgroup/dcrlibwallet"
+	"github.com/raedahgroup/godcr/fyne/assets"
+	"github.com/raedahgroup/godcr/fyne/widgets"
+)
+
+var OverviewHandlerLock sync.Mutex
+
+type OverviewHandler struct {
+	Synced         bool
+	Syncing        bool
+	SyncProgress   float64
+	ConnectedPeers int32
+
+	Balance            []*canvas.Text
+	Transactions       []dcrlibwallet.Transaction
+	PageBox            fyne.CanvasObject
+	SyncStatusText     *canvas.Text
+	TimeLeftText       *widget.Label
+	ProgressBar        *widget.ProgressBar
+	BlockStatus        *fyne.Container
+	Table              *widgets.Table
+	ConnectedPeersText *widget.Label
+}
+
+type TransactionUpdate struct {
+	WalletId    int
+	TxnHash     string
+	Transaction dcrlibwallet.Transaction
+}
+
+func (handler *OverviewHandler) UpdateBalance(multiWallet *dcrlibwallet.MultiWallet) {
+	tb, _ := totalBalance(multiWallet)
+	mainBalance, subBalance := breakBalance(tb)
+	handler.Balance[0].Text = mainBalance
+	handler.Balance[1].Text = subBalance
+	for _, w := range handler.Balance {
+		canvas.Refresh(w)
+	}
+}
+
+func (handler *OverviewHandler) UpdateBlockStatusBox(wallet *dcrlibwallet.MultiWallet) {
+	handler.UpdateTimestamp(wallet, false)
+	handler.UpdateSyncStatus(wallet, false)
+	handler.UpdateConnectedPeers(wallet.ConnectedPeers(), false)
+	widget.Refresh(handler.ProgressBar)
+	canvas.Refresh(handler.BlockStatus)
+}
+
+func (handler *OverviewHandler) UpdateTransactions(wallet *dcrlibwallet.MultiWallet, update TransactionUpdate) {
+	var transactionList []*widget.Box
+	var height int32
+
+	height = wallet.GetBestBlock().Height
+	if len(handler.Table.Result.Children) > 1 {
+		handler.Table.DeleteAll()
+	}
+
+	if update.Transaction.Hash != "" {
+		var oldTransactions []dcrlibwallet.Transaction
+		if len(handler.Transactions) > 0 {
+			oldTransactions = handler.Transactions[1:]
+		}
+
+		handler.Transactions = []dcrlibwallet.Transaction{update.Transaction}
+		handler.Transactions = append(handler.Transactions, oldTransactions...)
+	} else if update.WalletId != 0 && update.TxnHash != "" {
+		txn, err := wallet.WalletWithID(update.WalletId).GetTransactionRaw([]byte(update.TxnHash))
+		if err != nil {
+			log.Printf("error fetching transaction %v", err.Error())
+			return
+		}
+
+		handler.Transactions = append(handler.Transactions, *txn)
+	} else {
+		var err error
+		handler.Transactions, err = recentTransactions(wallet)
+		if err != nil {
+			log.Printf("error recentTransactions %v", err.Error())
+			return
+		}
+	}
+
+	for _, txn := range handler.Transactions {
+		amount := dcrutil.Amount(txn.Amount).String()
+		fee := dcrutil.Amount(txn.Fee).String()
+		timeDate := dcrlibwallet.ExtractDateOrTime(txn.Timestamp)
+		status := transactionStatus(height, txn)
+		transactionList = append(transactionList, newTransactionRow(transactionIcon(txn.Direction), amount, fee,
+			dcrlibwallet.TransactionDirectionName(txn.Direction), status, timeDate))
+	}
+	handler.Table.Append(transactionList...)
+}
+
+func (handler *OverviewHandler) UpdateSyncStatus (wallet *dcrlibwallet.MultiWallet, refresh bool) {
+	status := handler.SyncStatusText
+	progressBar := handler.ProgressBar
+	handler.Syncing = wallet.IsSyncing()
+	handler.Synced = wallet.IsSynced()
+	if wallet.IsSynced() {
+		handler.SyncProgress = 1
+	}
+	status.Text, status.Color, progressBar.Value = handler.blockSyncStatus()
+	if refresh {
+		widget.Refresh(progressBar)
+		canvas.Refresh(status)
+	}
+}
+
+func (handler *OverviewHandler) UpdateSyncProgress(progressReport *dcrlibwallet.HeadersFetchProgressReport) {
+	timeInString := strconv.Itoa(int(progressReport.GeneralSyncProgress.TotalTimeRemainingSeconds))
+	handler.TimeLeftText.Text = timeInString + " secs left"
+	widget.Refresh(handler.TimeLeftText)
+}
+
+func (handler *OverviewHandler) UpdateConnectedPeers(peers int32, refresh bool) {
+	handler.ConnectedPeersText.SetText(fmt.Sprintf("Connected peers count  %d", peers))
+	if refresh {
+		widget.Refresh(handler.ConnectedPeersText)
+	}
+}
+
+func (handler *OverviewHandler) UpdateTimestamp(wallet *dcrlibwallet.MultiWallet, refresh bool) {
+	handler.TimeLeftText.SetText(bestBlockInfo(wallet.GetBestBlock().Height, wallet.GetBestBlock().Timestamp))
+	if refresh {
+		widget.Refresh(handler.TimeLeftText)
+	}
+}
+
+func (handler *OverviewHandler) blockSyncStatus() (string, color.Color, float64) {
+	if handler.Syncing {
+		return "Syncing...", color.Gray{Y: 123}, handler.SyncProgress
+	}
+	if handler.Synced {
+		return "Synced", color.Gray{Y: 123}, handler.SyncProgress
+	}
+
+	return "Not Synced", color.Gray{Y: 123}, handler.SyncProgress
+}
+
+func bestBlockInfo(blockHeight int32, timestamp int64) string {
+	blockTimeStamp := time.Unix(timestamp, 0)
+	timeLeft := time.Now().Sub(blockTimeStamp).Round(time.Second).String()
+	return timeLeft + " ago"
+}
+
+func newTransactionRow(transactionType, amount, fee, direction, status, date string) *widget.Box {
+	icons, _ := assets.GetIcons(assets.ReceiveIcon, assets.SendIcon)
+	icon := canvas.NewImageFromResource(icons[transactionType])
+	icon.SetMinSize(fyne.NewSize(5, 20))
+	iconBox := widget.NewVBox(widgets.NewVSpacer(4), icon)
+	amountLabel := widget.NewLabel(amount)
+	feeLabel := widget.NewLabel(fee)
+	dateLabel := widget.NewLabel(date)
+	statusLabel := widget.NewLabel(status)
+	directionLabel := widget.NewLabel(direction)
+	column := widget.NewHBox(iconBox, amountLabel, feeLabel, directionLabel, statusLabel, dateLabel)
+	return column
+}
+
+func totalBalance(multiWallet *dcrlibwallet.MultiWallet) (balance string, err error) {
+	var totalWalletBalance int64
+	walletIds := multiWallet.OpenedWalletIDsRaw()
+	sort.Ints(walletIds)
+	for _, id := range walletIds {
+		accounts, err := multiWallet.WalletWithID(id).GetAccountsRaw(dcrlibwallet.DefaultRequiredConfirmations)
+		if err != nil {
+			return "", err
+		}
+		for _, acc := range accounts.Acc {
+			totalWalletBalance += acc.TotalBalance
+		}
+	}
+	balance = dcrutil.Amount(totalWalletBalance).String()
+	return
+}
+
+func breakBalance(balance string) (b1, b2 string) {
+	balanceParts := strings.Split(balance, ".")
+	b1 = balanceParts[0]
+	b2 = balanceParts[1]
+	b1 = b1 + "." + b2[:2]
+	b2 = b2[2:]
+	return
+}
+
+func transactionIcon(direction int32) string {
+	switch direction {
+	case 0:
+		return assets.SendIcon
+	case 1:
+		return assets.ReceiveIcon
+	case 2:
+		return assets.ReceiveIcon
+	default:
+		return assets.InfoIcon
+	}
+}
+
+func transactionStatus(bestBlockHeight int32, txn dcrlibwallet.Transaction) string {
+	confirmations := bestBlockHeight - txn.BlockHeight + 1
+	if txn.BlockHeight != -1 && confirmations > dcrlibwallet.DefaultRequiredConfirmations {
+		return "confirmed"
+	}
+
+	return "pending"
+}
+
+func recentTransactions(wallet *dcrlibwallet.MultiWallet) (transactions []dcrlibwallet.Transaction, err error) {
+	walletIds := wallet.OpenedWalletIDsRaw()
+
+	// add recent transactions of all wallets to a single slice
+	for _, id := range walletIds {
+		txns, err := wallet.WalletWithID(id).GetTransactionsRaw(0, 10, 0, true)
+		transactions = append(transactions, txns...)
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.SliceStable(transactions, func(i, j int) bool {
+		backTime := time.Unix(transactions[j].Timestamp, 0)
+		frontTime := time.Unix(transactions[i].Timestamp, 0)
+		return backTime.Before(frontTime)
+	})
+	if len(transactions) > 5 {
+		transactions = transactions[:5]
+	}
+
+	return
+}

--- a/fyne/pages/display.go
+++ b/fyne/pages/display.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
 
+
 	"github.com/decred/slog"
 	"github.com/raedahgroup/dcrlibwallet"
 
@@ -56,6 +57,7 @@ func (app *AppInterface) DisplayMainWindow() {
 	app.Window.SetFixedSize(true)
 	app.Window.CenterOnScreen()
 	fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
+	go overviewHandler.PreserveSyncSteps()
 	app.Window.ShowAndRun()
 	app.tearDown()
 }

--- a/fyne/pages/handler/overview.go
+++ b/fyne/pages/handler/overview.go
@@ -1,4 +1,4 @@
-package handlers
+package handler
 
 import (
 	"fmt"
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"fyne.io/fyne"
@@ -22,8 +21,6 @@ import (
 	"github.com/raedahgroup/godcr/fyne/widgets"
 )
 
-var OverviewHandlerLock sync.Mutex
-
 type OverviewHandler struct {
 	Synced          bool
 	Syncing         bool
@@ -32,21 +29,26 @@ type OverviewHandler struct {
 	Steps           int32
 	hideSyncDetails bool
 
+	Container            fyne.CanvasObject
 	Balance              []*canvas.Text
 	Transactions         []dcrlibwallet.Transaction
-	PageBox              fyne.CanvasObject
+	PageBoxes            fyne.CanvasObject
 	SyncStatusWidget     *canvas.Text
 	TimeLeftWidget       *widget.Label
+	BlockHeightTime 	 *widget.Label
 	ProgressBar          *widget.ProgressBar
-	BlockStatus          *fyne.Container
+	BlockStatus 		 *fyne.Container
+	BlockStatusSynced          fyne.CanvasObject
+	BlockStatusSyncing         fyne.CanvasObject
 	Table                *widgets.Table
 	ConnectedPeersWidget *widget.Label
 	SyncStepWidget       *widget.Label
 	BlockHeadersWidget   *widget.Label
 	WalletSyncInfo       *fyne.Container
-	WalletSyncInfoToggle *widgets.ClickableBox
-	WalletSyncInfoToggleText	 *widget.Label
-	Scroll *widget.ScrollContainer
+	Scroll               *widget.ScrollContainer
+	CancelButton 		 *widget.Button
+
+	StepsChannel chan int32
 }
 
 type TransactionUpdate struct {
@@ -55,22 +57,44 @@ type TransactionUpdate struct {
 	Transaction dcrlibwallet.Transaction
 }
 
+func (handler *OverviewHandler) RenderContent() {
+	// todo
+}
+
 func (handler *OverviewHandler) UpdateBalance(multiWallet *dcrlibwallet.MultiWallet) {
 	tb, _ := totalBalance(multiWallet)
 	mainBalance, subBalance := breakBalance(tb)
 	handler.Balance[0].Text = mainBalance
 	handler.Balance[1].Text = subBalance
 	for _, w := range handler.Balance {
-		canvas.Refresh(w)
+		w.Refresh()
 	}
 }
 
 func (handler *OverviewHandler) UpdateBlockStatusBox(wallet *dcrlibwallet.MultiWallet) {
-	handler.UpdateTimestamp(wallet, false)
 	handler.UpdateSyncStatus(wallet, false)
-	handler.UpdateConnectedPeers(wallet.ConnectedPeers(), false)
-	widget.Refresh(handler.ProgressBar)
-	canvas.Refresh(handler.BlockStatus)
+	if handler.Syncing {
+		fmt.Printf("\n \n SYNCING \n \n")
+		handler.BlockStatus.Objects = []fyne.CanvasObject{}
+		handler.BlockStatus.AddObject(handler.BlockStatusSyncing)
+		handler.UpdateTimestamp(wallet, false)
+		handler.UpdateConnectedPeers(wallet.ConnectedPeers(), false)
+		handler.UpdateProgressBar(false)
+		// handler.UpdateSyncSteps(false)
+		// handler.UpdateBlockHeadersSync(int32(math.Round(handler.SyncProgress)*100), false)
+	} else if handler.Synced {
+		fmt.Printf("\n \n SYNCED \n \n")
+		handler.BlockStatus.Objects = []fyne.CanvasObject{}
+		handler.BlockStatus.AddObject(handler.BlockStatusSynced)
+		fmt.Printf("\n \n done adding object \n ")
+		handler.UpdateConnectedPeers(wallet.ConnectedPeers(), false)
+		fmt.Printf(" done updating peers \n \n")
+		handler.UpdateBlockHeightTime(wallet, false)
+	}  else {
+		fmt.Printf("\n \n nothing to add yet... \n \n")
+	}
+
+	handler.Container.Refresh()
 }
 
 func (handler *OverviewHandler) UpdateTransactions(wallet *dcrlibwallet.MultiWallet, update TransactionUpdate) {
@@ -123,56 +147,57 @@ func (handler *OverviewHandler) UpdateSyncStatus(wallet *dcrlibwallet.MultiWalle
 	progressBar := handler.ProgressBar
 	handler.Syncing = wallet.IsSyncing()
 	handler.Synced = wallet.IsSynced()
-	if wallet.IsSynced() {
+	if handler.Synced {
 		handler.SyncProgress = 1
+		handler.hideSyncDetails = true
 	}
 
 	handler.UpdateProgressBar(false)
 	status.Text, status.Color = handler.blockSyncStatus()
 	if refresh {
-		widget.Refresh(progressBar)
-		canvas.Refresh(status)
+		progressBar.Refresh()
+		status.Refresh()
 	}
 }
 
 func (handler *OverviewHandler) UpdateSyncProgress(progressReport *dcrlibwallet.HeadersFetchProgressReport) {
 	timeInString := strconv.Itoa(int(progressReport.GeneralSyncProgress.TotalTimeRemainingSeconds))
 	handler.TimeLeftWidget.Text = timeInString + " secs left"
-	widget.Refresh(handler.TimeLeftWidget)
+	handler.TimeLeftWidget.Refresh()
 }
 
 func (handler *OverviewHandler) UpdateConnectedPeers(peers int32, refresh bool) {
 	handler.ConnectedPeersWidget.SetText(fmt.Sprintf("Connected peers count  %d", peers))
 	if refresh {
-		widget.Refresh(handler.ConnectedPeersWidget)
+		handler.ConnectedPeersWidget.Refresh()
 	}
 }
 
 func (handler *OverviewHandler) UpdateTimestamp(wallet *dcrlibwallet.MultiWallet, refresh bool) {
 	handler.TimeLeftWidget.SetText(bestBlockInfo(wallet.GetBestBlock().Height, wallet.GetBestBlock().Timestamp))
 	if refresh {
-		widget.Refresh(handler.TimeLeftWidget)
+		handler.TimeLeftWidget.Refresh()
 	}
 }
 
 func (handler *OverviewHandler) UpdateProgressBar(refresh bool) {
 	handler.ProgressBar.Value = handler.SyncProgress
 	if refresh {
-		widget.Refresh(handler.ProgressBar)
+		handler.ProgressBar.Refresh()
 	}
 }
 
 func (handler *OverviewHandler) UpdateSyncSteps(refresh bool) {
-	handler.SyncStepWidget.Text = fmt.Sprintf("Step 1/%d", handler.Steps)
+	handler.SyncStepWidget.SetText(fmt.Sprintf("Step %d/3", handler.Steps))
 	if refresh {
-		widget.Refresh(handler.SyncStepWidget)
+		handler.SyncStepWidget.Refresh()
 	}
 }
 
-func (handler *OverviewHandler) UpdateBlockHeadersSync(status float64, refresh bool) {
-	handler.BlockHeadersWidget.Text = fmt.Sprintf("Fetching block headers  %f%%", status)
+func (handler *OverviewHandler) UpdateBlockHeadersSync(status int32, refresh bool) {
+	handler.BlockHeadersWidget.SetText(fmt.Sprintf("Fetching block headers  %v%%", status))
 	if refresh {
-		widget.Refresh(handler.BlockHeadersWidget)
+		handler.BlockHeadersWidget.Refresh()
 	}
 }
 
@@ -190,6 +215,7 @@ func (handler *OverviewHandler) blockSyncStatus() (string, color.Color) {
 func (handler *OverviewHandler) CancelSync(wallet *dcrlibwallet.MultiWallet) {
 	if wallet.IsSyncing() {
 		wallet.CancelSync()
+		handler.ConnectedPeers = 0
 		err := beeep.Notify("Sync Canceled", "wallet sync stopped until app restart", "assets/information.png")
 		if err != nil {
 			log.Println("error initiating alert:", err.Error())
@@ -204,6 +230,7 @@ func (handler *OverviewHandler) UpdateWalletsSyncBox(wallet *dcrlibwallet.MultiW
 		w := wallet.WalletWithID(id)
 		headersFetched := fmt.Sprintf("%d of %d", w.GetBestBlock(), wallet.GetBestBlock().Height)
 		progress := fmt.Sprintf("%s behind", dcrlibwallet.CalculateDaysBehind(w.GetBestBlockTimeStamp()))
+		handler.WalletSyncInfo.Objects = []fyne.CanvasObject{}
 		handler.WalletSyncInfo.AddObject(
 			walletSyncBox(
 				w.Name,
@@ -213,22 +240,18 @@ func (handler *OverviewHandler) UpdateWalletsSyncBox(wallet *dcrlibwallet.MultiW
 			),
 		)
 	}
-	handler.Scroll.Resize(fyne.NewSize(510, 70))
-	widget.Refresh(handler.Scroll)
-	canvas.Refresh(handler.WalletSyncInfo)
-	fmt.Printf("SCROLLER %v",handler.Scroll.MinSize())
+	handler.WalletSyncInfo.Refresh()
+	return
 }
 
-func (handler *OverviewHandler) HideWalletSyncBox() {
-	if handler.hideSyncDetails {
-		handler.hideSyncDetails = !handler.hideSyncDetails
-		handler.WalletSyncInfoToggleText.Text = "show details"
-	} else {
-		handler.hideSyncDetails  = !handler.hideSyncDetails
-		handler.WalletSyncInfoToggleText.Text = "hide details"
+func (handler *OverviewHandler) UpdateBlockHeightTime(wallet *dcrlibwallet.MultiWallet, refresh bool) {
+	blockTimeStamp := time.Unix(wallet.GetBestBlock().Timestamp, 0)
+	timeLeft := time.Now().Sub(blockTimeStamp).Round(time.Second).String()
+	text := fmt.Sprintf("Latest block %v . %v ago", wallet.GetBestBlock().Height, timeLeft)
+	handler.BlockHeightTime.SetText(text)
+	if refresh {
+		handler.BlockHeightTime.Refresh()
 	}
-
-	// handler.WalletSyncInfoToggle.Refresh()
 }
 
 func walletSyncStatus(wallet *dcrlibwallet.Wallet, bestBlockHeight int32) string {
@@ -266,6 +289,9 @@ func totalBalance(multiWallet *dcrlibwallet.MultiWallet) (balance string, err er
 
 func breakBalance(balance string) (b1, b2 string) {
 	balanceParts := strings.Split(balance, ".")
+	if len(balanceParts) == 1 {
+		return balanceParts[0], ""
+	}
 	b1 = balanceParts[0]
 	b2 = balanceParts[1]
 	b1 = b1 + "." + b2[:2]
@@ -371,4 +397,20 @@ func walletSyncBox(name, status, headerFetched, progress string) fyne.CanvasObje
 			walletSyncContent,
 		),
 	)
+}
+
+func (handler *OverviewHandler) PreserveSyncSteps() {
+	handler.StepsChannel = make(chan int32)
+	defer func() {
+		fmt.Printf("\n \n Preserve sync step go routine has been killed!\n \n")
+	}()
+	handler.Steps = 0
+	for {
+		select {
+		case progress := <-handler.StepsChannel:
+			if progress == 100 && handler.Steps < 3{
+				handler.Steps += 1
+			}
+		}
+	}
 }

--- a/fyne/pages/handler/overview.go
+++ b/fyne/pages/handler/overview.go
@@ -35,18 +35,18 @@ type OverviewHandler struct {
 	PageBoxes            fyne.CanvasObject
 	SyncStatusWidget     *canvas.Text
 	TimeLeftWidget       *widget.Label
-	BlockHeightTime 	 *widget.Label
+	BlockHeightTime      *widget.Label
 	ProgressBar          *widget.ProgressBar
-	BlockStatus 		 *fyne.Container
-	BlockStatusSynced          fyne.CanvasObject
-	BlockStatusSyncing         fyne.CanvasObject
+	BlockStatus          *fyne.Container
+	BlockStatusSynced    fyne.CanvasObject
+	BlockStatusSyncing   fyne.CanvasObject
 	Table                *widgets.Table
 	ConnectedPeersWidget *widget.Label
 	SyncStepWidget       *widget.Label
 	BlockHeadersWidget   *widget.Label
 	WalletSyncInfo       *fyne.Container
 	Scroll               *widget.ScrollContainer
-	CancelButton 		 *widget.Button
+	CancelButton         *widget.Button
 
 	StepsChannel chan int32
 }
@@ -55,10 +55,6 @@ type TransactionUpdate struct {
 	WalletId    int
 	TxnHash     string
 	Transaction dcrlibwallet.Transaction
-}
-
-func (handler *OverviewHandler) RenderContent() {
-	// todo
 }
 
 func (handler *OverviewHandler) UpdateBalance(multiWallet *dcrlibwallet.MultiWallet) {
@@ -73,25 +69,17 @@ func (handler *OverviewHandler) UpdateBalance(multiWallet *dcrlibwallet.MultiWal
 
 func (handler *OverviewHandler) UpdateBlockStatusBox(wallet *dcrlibwallet.MultiWallet) {
 	handler.UpdateSyncStatus(wallet, false)
-	if handler.Syncing {
-		fmt.Printf("\n \n SYNCING \n \n")
+	if handler.Synced {
+		handler.BlockStatus.Objects = []fyne.CanvasObject{}
+		handler.BlockStatus.AddObject(handler.BlockStatusSynced)
+		handler.UpdateConnectedPeers(wallet.ConnectedPeers(), false)
+		handler.UpdateBlockHeightTime(wallet, false)
+	} else {
 		handler.BlockStatus.Objects = []fyne.CanvasObject{}
 		handler.BlockStatus.AddObject(handler.BlockStatusSyncing)
 		handler.UpdateTimestamp(wallet, false)
 		handler.UpdateConnectedPeers(wallet.ConnectedPeers(), false)
 		handler.UpdateProgressBar(false)
-		// handler.UpdateSyncSteps(false)
-		// handler.UpdateBlockHeadersSync(int32(math.Round(handler.SyncProgress)*100), false)
-	} else if handler.Synced {
-		fmt.Printf("\n \n SYNCED \n \n")
-		handler.BlockStatus.Objects = []fyne.CanvasObject{}
-		handler.BlockStatus.AddObject(handler.BlockStatusSynced)
-		fmt.Printf("\n \n done adding object \n ")
-		handler.UpdateConnectedPeers(wallet.ConnectedPeers(), false)
-		fmt.Printf(" done updating peers \n \n")
-		handler.UpdateBlockHeightTime(wallet, false)
-	}  else {
-		fmt.Printf("\n \n nothing to add yet... \n \n")
 	}
 
 	handler.Container.Refresh()
@@ -240,6 +228,7 @@ func (handler *OverviewHandler) UpdateWalletsSyncBox(wallet *dcrlibwallet.MultiW
 			),
 		)
 	}
+
 	handler.WalletSyncInfo.Refresh()
 	return
 }
@@ -261,6 +250,7 @@ func walletSyncStatus(wallet *dcrlibwallet.Wallet, bestBlockHeight int32) string
 	if wallet.GetBestBlock() < bestBlockHeight {
 		return "syncing"
 	}
+
 	return "synced"
 }
 
@@ -283,6 +273,7 @@ func totalBalance(multiWallet *dcrlibwallet.MultiWallet) (balance string, err er
 			totalWalletBalance += acc.TotalBalance
 		}
 	}
+
 	balance = dcrutil.Amount(totalWalletBalance).String()
 	return
 }
@@ -408,7 +399,7 @@ func (handler *OverviewHandler) PreserveSyncSteps() {
 	for {
 		select {
 		case progress := <-handler.StepsChannel:
-			if progress == 100 && handler.Steps < 3{
+			if progress == 100 && handler.Steps < 3 {
 				handler.Steps += 1
 			}
 		}

--- a/fyne/pages/handler/values/dimensions.go
+++ b/fyne/pages/handler/values/dimensions.go
@@ -6,9 +6,11 @@ const (
 
 	TextSize10                 = 10
 	TextSize12                 = 12
+	TextSize15                 = 15
 	TextSize16                 = 16
 	TextSize14                 = 14
 	TextSize24                 = 24
+	TextSize25                 = 25
 	TextSize20                 = 20
 	TextSize32                 = 32
 	ConfirmationButtonTextSize = 18

--- a/fyne/pages/overview.go
+++ b/fyne/pages/overview.go
@@ -5,12 +5,13 @@ import (
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/layout"
 	"fyne.io/fyne/widget"
+	"github.com/raedahgroup/godcr/fyne/pages/handler"
+	"github.com/raedahgroup/godcr/fyne/pages/handler/values"
 	"image/color"
 	"sort"
 	"time"
 
 	"github.com/raedahgroup/dcrlibwallet"
-	"github.com/raedahgroup/godcr/fyne/handlers"
 	"github.com/raedahgroup/godcr/fyne/widgets"
 )
 
@@ -18,20 +19,18 @@ const historyPageIndex = 1
 const PageTitle = "overview"
 
 type overview struct {
-	app            *AppInterface
-	multiWallet    *dcrlibwallet.MultiWallet
-	walletIds      []int
-	transactions   []dcrlibwallet.Transaction
+	app          *AppInterface
+	multiWallet  *dcrlibwallet.MultiWallet
+	walletIds    []int
+	transactions []dcrlibwallet.Transaction
 }
 
-var overviewHandler = &handlers.OverviewHandler{}
+var overviewHandler = &handler.OverviewHandler{}
 
-// todo: display overview page (include sync progress UI elements)
-// todo: register sync progress listener on overview page to update sync progress views
 func overviewPageContent(app *AppInterface) fyne.CanvasObject {
 	ov := &overview{}
 	ov.app = app
-	app.Window.Resize(fyne.NewSize(650, 650))
+	//app.Window.Resize(fyne.NewSize(650, 680))
 	ov.multiWallet = app.MultiWallet
 	ov.walletIds = ov.multiWallet.OpenedWalletIDsRaw()
 	if len(ov.walletIds) == 0 {
@@ -39,26 +38,26 @@ func overviewPageContent(app *AppInterface) fyne.CanvasObject {
 	}
 	sort.Ints(ov.walletIds)
 
-	defer func (){
-		overviewHandler.UpdateBalance(app.MultiWallet)
-		handlers.OverviewHandlerLock.Lock()
-		overviewHandler.UpdateBlockStatusBox(app.MultiWallet)
-		handlers.OverviewHandlerLock.Unlock()
+	defer func() {
+		go overviewHandler.UpdateBalance(app.MultiWallet)
+		go overviewHandler.UpdateBlockStatusBox(app.MultiWallet)
 	}()
 	go func() {
 		time.Sleep(200 * time.Millisecond)
 		overviewHandler.UpdateWalletsSyncBox(app.MultiWallet)
 	}()
 
-	return widget.NewHBox(widgets.NewHSpacer(18), ov.container())
+	overviewHandler.Container = ov.container()
+	return widget.NewHBox(widgets.NewHSpacer(18), overviewHandler.Container)
 }
 
 func (ov *overview) container() fyne.CanvasObject {
+	overviewHandler.PageBoxes = ov.pageBoxes()
 	overviewContainer := widget.NewVBox(
 		title(),
 		balance(),
-		widgets.NewVSpacer(50),
-		ov.pageBoxes(),
+		widgets.NewVSpacer(25),
+		overviewHandler.PageBoxes,
 	)
 	return overviewContainer
 }
@@ -72,46 +71,43 @@ func (ov *overview) pageBoxes() (object fyne.CanvasObject) {
 }
 
 func (ov *overview) recentTransactionBox() fyne.CanvasObject {
-	//var err error
-	//overviewHandler.Transactions, err = recentTransactions(ov)
-	//if err != nil {
-	//	return widget.NewHBox(widgets.NewHSpacer(10), widget.NewLabelWithStyle(err.Error(), fyne.TextAlignCenter, fyne.TextStyle{Bold: true}))
-	//}
-
 	table := &widgets.Table{}
 	table.NewTable(transactionRowHeader())
 	overviewHandler.Table = table
-	overviewHandler.UpdateTransactions(ov.multiWallet, handlers.TransactionUpdate{})
+	overviewHandler.UpdateTransactions(ov.multiWallet, handler.TransactionUpdate{})
 	return widget.NewVBox(
 		table.Result,
 		fyne.NewContainerWithLayout(layout.NewHBoxLayout(),
 			layout.NewSpacer(),
 			widgets.NewClickableBox(
-				widget.NewHBox(widget.NewLabelWithStyle("see all", fyne.TextAlignCenter, fyne.TextStyle{Italic: true})),
+				widget.NewHBox(widget.NewLabelWithStyle("see all", fyne.TextAlignCenter, fyne.TextStyle{})),
 				func() {
 					ov.app.tabMenu.SelectTabIndex(historyPageIndex)
 				},
 			),
+			widgets.NewVSpacer(40),
 			layout.NewSpacer(),
 		),
 	)
 }
 
 func (ov *overview) blockStatusBox() fyne.CanvasObject {
-	syncStatusText := widgets.NewSmallText("", color.Black)
-	timeLeft := widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{Italic: true})
-	connectedPeers := widget.NewLabelWithStyle("", fyne.TextAlignTrailing, fyne.TextStyle{Italic: true})
+	overviewHandler.BlockStatusSyncing = ov.blockStatusBoxSyncing()
+	overviewHandler.BlockStatusSynced = ov.blockStatusBoxSynced()
+	overviewHandler.BlockStatus = fyne.NewContainerWithLayout(layout.NewVBoxLayout())
+	return overviewHandler.BlockStatus
+}
+
+func (ov *overview) blockStatusBoxSyncing() fyne.CanvasObject {
+	syncStatusText := widgets.NewSmallText("Syncing...", values.DefaultTextColor)
+	timeLeft := widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{})
+	connectedPeers := widget.NewLabelWithStyle("", fyne.TextAlignTrailing, fyne.TextStyle{})
 	progressBar := widget.NewProgressBar()
-	syncSteps := widget.NewLabelWithStyle("Step 1/3", fyne.TextAlignTrailing, fyne.TextStyle{Italic: true})
-	blockHeadersStatus := widget.NewLabelWithStyle("Fetching block headers  89%", fyne.TextAlignTrailing, fyne.TextStyle{Italic: true})
-	walletSyncInfo := fyne.NewContainerWithLayout(layout.NewGridLayout(2))
+	syncSteps := widget.NewLabelWithStyle("Step 0/3", fyne.TextAlignTrailing, fyne.TextStyle{})
+	blockHeadersStatus := widget.NewLabelWithStyle("Fetching block headers  0%", fyne.TextAlignTrailing, fyne.TextStyle{})
+	walletSyncInfo := fyne.NewContainerWithLayout(layout.NewHBoxLayout())
 	walletSyncScrollContainer := widget.NewScrollContainer(walletSyncInfo)
-	walletSyncInfoToggleText := widget.NewLabelWithStyle("hide details", fyne.TextAlignCenter, fyne.TextStyle{Italic: true})
-	walletSyncInfoToggle := widgets.NewClickableBox(widget.NewHBox(walletSyncInfoToggleText),
-		func() {
-			overviewHandler.HideWalletSyncBox()
-		},
-	)
+	cancelButton := widget.NewButton("Cancel", func() {overviewHandler.CancelSync(ov.multiWallet)})
 
 	overviewHandler.SyncStatusWidget = syncStatusText
 	overviewHandler.TimeLeftWidget = timeLeft
@@ -120,16 +116,14 @@ func (ov *overview) blockStatusBox() fyne.CanvasObject {
 	overviewHandler.SyncStepWidget = syncSteps
 	overviewHandler.BlockHeadersWidget = blockHeadersStatus
 	overviewHandler.WalletSyncInfo = walletSyncInfo
-	overviewHandler.WalletSyncInfoToggle = walletSyncInfoToggle
-	overviewHandler.WalletSyncInfoToggleText = walletSyncInfoToggleText
 	overviewHandler.Scroll = walletSyncScrollContainer
+	overviewHandler.CancelButton = cancelButton
+	overviewHandler.BlockHeightTime = widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{})
 	top := fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(515, 24)),
 		widget.NewHBox(
 			syncStatusText,
 			layout.NewSpacer(),
-			widget.NewButton("Cancel", func() {
-				overviewHandler.CancelSync(ov.multiWallet)
-			}),
+			cancelButton,
 		))
 	progressBarContainer := fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(515, 20)),
 		progressBar,
@@ -146,24 +140,35 @@ func (ov *overview) blockStatusBox() fyne.CanvasObject {
 		syncDuration,
 		syncStatus,
 		widgets.NewVSpacer(15),
-		walletSyncScrollContainer,
-		fyne.NewContainerWithLayout(layout.NewHBoxLayout(),
-			layout.NewSpacer(),
-			widgets.NewClickableBox(
-				widget.NewHBox(walletSyncInfoToggleText),
-				func() {
-					overviewHandler.HideWalletSyncBox()
-				},
-			),
-			layout.NewSpacer(),
-		),
+		fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(510, 80)), walletSyncScrollContainer),
+	)
+	return blockStatus
+}
+
+func (ov *overview) blockStatusBoxSynced() fyne.CanvasObject {
+	syncStatusText := widgets.NewSmallText("Synced", color.Black)
+	blockHeightTime := widget.NewLabelWithStyle("Latest block 0 . 0s ago", fyne.TextAlignLeading, fyne.TextStyle{})
+
+	overviewHandler.SyncStatusWidget = syncStatusText
+	overviewHandler.BlockHeightTime = blockHeightTime
+	top := fyne.NewContainerWithLayout(layout.NewHBoxLayout(),
+			syncStatusText,
+			layout.NewSpacer())
+	syncedStatus := fyne.NewContainerWithLayout(layout.NewBorderLayout(nil, nil, blockHeightTime, overviewHandler.ConnectedPeersWidget),
+		blockHeightTime, overviewHandler.ConnectedPeersWidget)
+
+	blockStatus := fyne.NewContainerWithLayout(layout.NewVBoxLayout(),
+		widgets.NewVSpacer(5),
+		top,
+		syncedStatus,
+		widgets.NewVSpacer(15),
 	)
 	overviewHandler.BlockStatus = blockStatus
 	return blockStatus
 }
 
 func title() fyne.CanvasObject {
-	titleWidget := widget.NewLabelWithStyle(PageTitle, fyne.TextAlignLeading, fyne.TextStyle{Bold: true, Italic: true})
+	titleWidget := widget.NewLabelWithStyle(PageTitle, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
 	return widget.NewHBox(titleWidget)
 }
 

--- a/fyne/pages/overview.go
+++ b/fyne/pages/overview.go
@@ -48,16 +48,18 @@ func overviewPageContent(app *AppInterface) fyne.CanvasObject {
 	}()
 
 	overviewHandler.Container = ov.container()
-	return widget.NewHBox(widgets.NewHSpacer(18), overviewHandler.Container)
+	return widget.NewHBox(widgets.NewHSpacer(values.Padding), overviewHandler.Container, widgets.NewHSpacer(values.Padding))
 }
 
 func (ov *overview) container() fyne.CanvasObject {
 	overviewHandler.PageBoxes = ov.pageBoxes()
 	overviewContainer := widget.NewVBox(
+		widgets.NewVSpacer(values.Padding),
 		title(),
 		balance(),
 		widgets.NewVSpacer(25),
 		overviewHandler.PageBoxes,
+		widgets.NewVSpacer(values.Padding),
 	)
 	return overviewContainer
 }
@@ -91,14 +93,7 @@ func (ov *overview) recentTransactionBox() fyne.CanvasObject {
 	)
 }
 
-func (ov *overview) blockStatusBox() fyne.CanvasObject {
-	overviewHandler.BlockStatusSyncing = ov.blockStatusBoxSyncing()
-	overviewHandler.BlockStatusSynced = ov.blockStatusBoxSynced()
-	overviewHandler.BlockStatus = fyne.NewContainerWithLayout(layout.NewVBoxLayout())
-	return overviewHandler.BlockStatus
-}
-
-func (ov *overview) blockStatusBoxSyncing() fyne.CanvasObject {
+func (ov *overview) initializeBlockStatusWidgets() {
 	syncStatusText := widgets.NewSmallText("Syncing...", values.DefaultTextColor)
 	timeLeft := widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{})
 	connectedPeers := widget.NewLabelWithStyle("", fyne.TextAlignTrailing, fyne.TextStyle{})
@@ -107,7 +102,9 @@ func (ov *overview) blockStatusBoxSyncing() fyne.CanvasObject {
 	blockHeadersStatus := widget.NewLabelWithStyle("Fetching block headers  0%", fyne.TextAlignTrailing, fyne.TextStyle{})
 	walletSyncInfo := fyne.NewContainerWithLayout(layout.NewHBoxLayout())
 	walletSyncScrollContainer := widget.NewScrollContainer(walletSyncInfo)
-	cancelButton := widget.NewButton("Cancel", func() {overviewHandler.CancelSync(ov.multiWallet)})
+	cancelButton := widget.NewButton("Cancel", func() { overviewHandler.CancelSync(ov.multiWallet)})
+	blockHeightTime := widget.NewLabelWithStyle("Latest block 0 . 0s ago", fyne.TextAlignLeading, fyne.TextStyle{})
+	overviewHandler.BlockHeightTime = widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{})
 
 	overviewHandler.SyncStatusWidget = syncStatusText
 	overviewHandler.TimeLeftWidget = timeLeft
@@ -118,53 +115,59 @@ func (ov *overview) blockStatusBoxSyncing() fyne.CanvasObject {
 	overviewHandler.WalletSyncInfo = walletSyncInfo
 	overviewHandler.Scroll = walletSyncScrollContainer
 	overviewHandler.CancelButton = cancelButton
-	overviewHandler.BlockHeightTime = widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{})
+	overviewHandler.BlockHeightTime = blockHeightTime
+}
+
+func (ov *overview) blockStatusBox() fyne.CanvasObject {
+	ov.initializeBlockStatusWidgets()
+	overviewHandler.BlockStatusSyncing = ov.blockStatusBoxSyncing()
+	overviewHandler.BlockStatusSynced = ov.blockStatusBoxSynced()
+	overviewHandler.BlockStatus = fyne.NewContainerWithLayout(layout.NewVBoxLayout())
+	return overviewHandler.BlockStatus
+}
+
+func (ov *overview) blockStatusBoxSyncing() fyne.CanvasObject {
+	h := overviewHandler
 	top := fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(515, 24)),
 		widget.NewHBox(
-			syncStatusText,
+			widgets.NewHSpacer(values.NilSpacer),
+			h.SyncStatusWidget,
 			layout.NewSpacer(),
-			cancelButton,
+			h.CancelButton,
 		))
 	progressBarContainer := fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(515, 20)),
-		progressBar,
-	)
-	syncDuration := fyne.NewContainerWithLayout(layout.NewBorderLayout(nil, nil, timeLeft, connectedPeers),
-		timeLeft, connectedPeers)
-	syncStatus := fyne.NewContainerWithLayout(layout.NewBorderLayout(nil, nil, syncSteps, blockHeadersStatus),
-		syncSteps, blockHeadersStatus)
+		h.ProgressBar)
+	syncDuration := fyne.NewContainerWithLayout(layout.NewBorderLayout(nil, nil, h.TimeLeftWidget, h.ConnectedPeersWidget),
+		h.TimeLeftWidget, h.ConnectedPeersWidget)
+	syncStatus := fyne.NewContainerWithLayout(layout.NewBorderLayout(nil, nil, h.SyncStepWidget, h.BlockHeadersWidget),
+		h.SyncStepWidget, h.BlockHeadersWidget)
 
-	blockStatus := fyne.NewContainerWithLayout(layout.NewVBoxLayout(),
+	return fyne.NewContainerWithLayout(layout.NewVBoxLayout(),
 		widgets.NewVSpacer(5),
 		top,
 		progressBarContainer,
 		syncDuration,
 		syncStatus,
 		widgets.NewVSpacer(15),
-		fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(510, 80)), walletSyncScrollContainer),
+		fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(510, 80)), h.Scroll),
 	)
-	return blockStatus
 }
 
 func (ov *overview) blockStatusBoxSynced() fyne.CanvasObject {
-	syncStatusText := widgets.NewSmallText("Synced", color.Black)
-	blockHeightTime := widget.NewLabelWithStyle("Latest block 0 . 0s ago", fyne.TextAlignLeading, fyne.TextStyle{})
-
-	overviewHandler.SyncStatusWidget = syncStatusText
-	overviewHandler.BlockHeightTime = blockHeightTime
+	h := overviewHandler
 	top := fyne.NewContainerWithLayout(layout.NewHBoxLayout(),
-			syncStatusText,
-			layout.NewSpacer())
-	syncedStatus := fyne.NewContainerWithLayout(layout.NewBorderLayout(nil, nil, blockHeightTime, overviewHandler.ConnectedPeersWidget),
-		blockHeightTime, overviewHandler.ConnectedPeersWidget)
+		widgets.NewHSpacer(values.NilSpacer),
+		h.SyncStatusWidget,
+		layout.NewSpacer())
+	syncedStatus := fyne.NewContainerWithLayout(layout.NewBorderLayout(nil, nil, h.BlockHeightTime, h.ConnectedPeersWidget),
+		h.BlockHeightTime, h.ConnectedPeersWidget)
 
-	blockStatus := fyne.NewContainerWithLayout(layout.NewVBoxLayout(),
+	return fyne.NewContainerWithLayout(layout.NewVBoxLayout(),
 		widgets.NewVSpacer(5),
 		top,
 		syncedStatus,
 		widgets.NewVSpacer(15),
 	)
-	overviewHandler.BlockStatus = blockStatus
-	return blockStatus
 }
 
 func title() fyne.CanvasObject {

--- a/fyne/pages/overview.go
+++ b/fyne/pages/overview.go
@@ -6,6 +6,7 @@ import (
 	"fyne.io/fyne/layout"
 	"fyne.io/fyne/widget"
 	"github.com/raedahgroup/dcrlibwallet"
+	"github.com/raedahgroup/godcr/fyne/layouts"
 	"github.com/raedahgroup/godcr/fyne/pages/handler"
 	"github.com/raedahgroup/godcr/fyne/pages/handler/values"
 	"github.com/raedahgroup/godcr/fyne/widgets"
@@ -14,7 +15,7 @@ import (
 )
 
 const historyPageIndex = 1
-const PageTitle = "overview"
+const PageTitle = "Overview"
 
 type overview struct {
 	app          *AppInterface
@@ -72,7 +73,7 @@ func (ov *overview) recentTransactionBox() fyne.CanvasObject {
 	table.NewTable(overviewHandler.TableHeader)
 	overviewHandler.Table = table
 	overviewHandler.UpdateTransactions(ov.multiWallet, handler.TransactionUpdate{})
-	transactionsContainer := fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(515, 200)), table.Container)
+	transactionsContainer := fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(520, 200)), table.Container)
 	overviewHandler.TransactionsContainer = transactionsContainer
 
 	return widget.NewVBox(
@@ -177,21 +178,20 @@ func title() fyne.CanvasObject {
 }
 
 func balance() fyne.CanvasObject {
-	dcrBalance := widgets.NewLargeText("0.00", color.Black)
-	dcrDecimals := widgets.NewSmallText("00000 DCR", color.Black)
+	dcrBalance := widgets.NewTextWithStyle("0.00", color.Black, fyne.TextStyle{}, fyne.TextAlignLeading, values.TextSize25)
+	dcrDecimals := widgets.NewTextWithStyle("00000 DCR", color.Black, fyne.TextStyle{}, fyne.TextAlignLeading, values.TextSize15)
 	overviewHandler.Balance = make([]*canvas.Text, 2)
 	overviewHandler.Balance[0] = dcrBalance
 	overviewHandler.Balance[1] = dcrDecimals
-	decimalsBox := fyne.NewContainerWithLayout(layout.NewVBoxLayout(), widgets.NewVSpacer(6), dcrDecimals)
-	return widget.NewHBox(widgets.NewVSpacer(10), dcrBalance, decimalsBox)
+	return fyne.NewContainerWithLayout(layouts.NewHBox(0, true), dcrBalance, dcrDecimals)
 }
 
 func transactionRowHeader() *widget.Box {
 	hash := widget.NewLabelWithStyle("#", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
-	amount := widget.NewLabelWithStyle("amount", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
-	fee := widget.NewLabelWithStyle("fee", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
-	direction := widget.NewLabelWithStyle("direction", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
-	status := widget.NewLabelWithStyle("status", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
-	date := widget.NewLabelWithStyle("date", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
+	amount := widget.NewLabelWithStyle("Amount", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
+	fee := widget.NewLabelWithStyle("Fee", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
+	direction := widget.NewLabelWithStyle("Direction", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
+	status := widget.NewLabelWithStyle("Status", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
+	date := widget.NewLabelWithStyle("Date", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
 	return widget.NewHBox(hash, amount, fee, direction, status, date)
 }

--- a/fyne/pages/overview.go
+++ b/fyne/pages/overview.go
@@ -1,10 +1,8 @@
 package pages
 
 import (
-	"fmt"
 	"image/color"
 	"sort"
-	"strings"
 	"time"
 
 	"fyne.io/fyne"
@@ -12,65 +10,53 @@ import (
 	"fyne.io/fyne/layout"
 	"fyne.io/fyne/widget"
 
-	"github.com/decred/dcrd/dcrutil"
 	"github.com/raedahgroup/dcrlibwallet"
-	"github.com/raedahgroup/godcr/fyne/assets"
-	"github.com/raedahgroup/godcr/fyne/pages/handler/values"
+	"github.com/raedahgroup/godcr/fyne/handlers"
 	"github.com/raedahgroup/godcr/fyne/widgets"
 )
 
 const historyPageIndex = 1
-const PageTitle = "Overview"
+const PageTitle = "overview"
 
 type overview struct {
 	app            *AppInterface
-	transactionBox *widget.Box
 	multiWallet    *dcrlibwallet.MultiWallet
 	walletIds      []int
 	transactions   []dcrlibwallet.Transaction
 }
+
+var overviewHandler = &handlers.OverviewHandler{}
 
 // todo: display overview page (include sync progress UI elements)
 // todo: register sync progress listener on overview page to update sync progress views
 func overviewPageContent(app *AppInterface) fyne.CanvasObject {
 	ov := &overview{}
 	ov.app = app
-	// app.Window.Resize(fyne.NewSize(650, 650))
+	app.Window.Resize(fyne.NewSize(650, 650))
 	ov.multiWallet = app.MultiWallet
 	ov.walletIds = ov.multiWallet.OpenedWalletIDsRaw()
 	if len(ov.walletIds) == 0 {
 		return widget.NewHBox(widgets.NewHSpacer(10), widget.NewLabelWithStyle("Could not retrieve wallets", fyne.TextAlignCenter, fyne.TextStyle{Bold: true}))
 	}
 	sort.Ints(ov.walletIds)
-	return widget.NewHBox(widgets.NewHSpacer(values.Padding), ov.container(), widgets.NewHSpacer(values.Padding))
+
+	defer func (){
+		overviewHandler.UpdateBalance(app.MultiWallet)
+		handlers.OverviewHandlerLock.Lock()
+		overviewHandler.UpdateBlockStatusBox(app.MultiWallet)
+		handlers.OverviewHandlerLock.Unlock()
+	}()
+	return widget.NewHBox(widgets.NewHSpacer(18), ov.container())
 }
 
 func (ov *overview) container() fyne.CanvasObject {
-	return widget.NewVBox(
-		widgets.NewVSpacer(values.Padding),
+	overviewContainer := widget.NewVBox(
 		title(),
-		ov.balance(),
+		balance(),
 		widgets.NewVSpacer(50),
 		ov.pageBoxes(),
-		widgets.NewVSpacer(values.Padding),
 	)
-}
-
-func title() fyne.CanvasObject {
-	titleWidget := widget.NewLabelWithStyle(PageTitle, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
-	return widget.NewHBox(titleWidget)
-}
-
-func (ov *overview) balance() fyne.CanvasObject {
-	tb, err := totalBalance(ov)
-	if err != nil {
-		return widget.NewLabel(fmt.Sprintf("Error: %s", err.Error()))
-	}
-	mainBalance, subBalance := breakBalance(tb)
-	dcrBalance := widgets.NewLargeText(mainBalance, color.Black)
-	dcrDecimals := widgets.NewSmallText(subBalance, color.Black)
-	decimalsBox := fyne.NewContainerWithLayout(layout.NewVBoxLayout(), widgets.NewVSpacer(6), dcrDecimals)
-	return widget.NewHBox(widgets.NewVSpacer(10), dcrBalance, decimalsBox)
+	return overviewContainer
 }
 
 func (ov *overview) pageBoxes() (object fyne.CanvasObject) {
@@ -82,23 +68,16 @@ func (ov *overview) pageBoxes() (object fyne.CanvasObject) {
 }
 
 func (ov *overview) recentTransactionBox() fyne.CanvasObject {
-	var err error
-	ov.transactions, err = recentTransactions(ov)
-	if err != nil {
-		return widget.NewHBox(widgets.NewHSpacer(10), widget.NewLabelWithStyle(err.Error(), fyne.TextAlignCenter, fyne.TextStyle{Bold: true}))
-	}
+	//var err error
+	//overviewHandler.Transactions, err = recentTransactions(ov)
+	//if err != nil {
+	//	return widget.NewHBox(widgets.NewHSpacer(10), widget.NewLabelWithStyle(err.Error(), fyne.TextAlignCenter, fyne.TextStyle{Bold: true}))
+	//}
 
 	table := &widgets.Table{}
 	table.NewTable(transactionRowHeader())
-	for _, txn := range ov.transactions {
-		amount := dcrutil.Amount(txn.Amount).String()
-		fee := dcrutil.Amount(txn.Fee).String()
-		timeDate := dcrlibwallet.ExtractDateOrTime(txn.Timestamp)
-		status := transactionStatus(ov, txn)
-		table.Append(newTransactionRow(transactionIcon(txn.Direction), amount, fee,
-			dcrlibwallet.TransactionDirectionName(txn.Direction), status, timeDate))
-	}
-
+	overviewHandler.Table = table
+	overviewHandler.UpdateTransactions(ov.multiWallet, handlers.TransactionUpdate{})
 	return widget.NewVBox(
 		table.Result,
 		fyne.NewContainerWithLayout(layout.NewHBoxLayout(),
@@ -115,17 +94,24 @@ func (ov *overview) recentTransactionBox() fyne.CanvasObject {
 }
 
 func blockStatusBox() fyne.CanvasObject {
+	syncStatusText := widgets.NewSmallText("", color.Black)
+	timeLeft := widget.NewLabelWithStyle("", fyne.TextAlignLeading, fyne.TextStyle{Italic: true})
+	connectedPeers := widget.NewLabelWithStyle("", fyne.TextAlignTrailing, fyne.TextStyle{Italic: true})
+	progressBar := widget.NewProgressBar()
+	overviewHandler.SyncStatusText = syncStatusText
+	overviewHandler.TimeLeftText = timeLeft
+	overviewHandler.ProgressBar = progressBar
+	overviewHandler.ConnectedPeersText = connectedPeers
+
 	top := fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(515, 24)),
 		widget.NewHBox(
-			widgets.NewSmallText("Syncing...", color.Black),
+			syncStatusText,
 			layout.NewSpacer(),
 			widget.NewButton("Cancel", func() {}),
 		))
-	progressBar := fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(515, 20)),
-		widget.NewProgressBar(),
+	progressBarContainer := fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(515, 20)),
+		progressBar,
 	)
-	timeLeft := widget.NewLabelWithStyle("6 min left", fyne.TextAlignLeading, fyne.TextStyle{Italic: true})
-	connectedPeers := widget.NewLabelWithStyle("Connected peers count  6", fyne.TextAlignTrailing, fyne.TextStyle{Italic: true})
 	syncSteps := widget.NewLabelWithStyle("Step 1/3", fyne.TextAlignTrailing, fyne.TextStyle{Italic: true})
 	blockHeadersStatus := widget.NewLabelWithStyle("Fetching block headers  89%", fyne.TextAlignTrailing, fyne.TextStyle{Italic: true})
 	syncDuration := fyne.NewContainerWithLayout(layout.NewBorderLayout(nil, nil, timeLeft, connectedPeers),
@@ -137,16 +123,36 @@ func blockStatusBox() fyne.CanvasObject {
 		walletSyncBox("Default", "waiting for other wallets", "6000 of 164864", "220 days behind"),
 		walletSyncBox("Wallet 2", "Syncing", "100 of 164864", "320 days behind"),
 	)
-
-	return fyne.NewContainerWithLayout(layout.NewVBoxLayout(),
+	blockStatus := fyne.NewContainerWithLayout(layout.NewVBoxLayout(),
 		widgets.NewVSpacer(5),
 		top,
-		progressBar,
+		progressBarContainer,
 		syncDuration,
 		syncStatus,
 		widgets.NewVSpacer(15),
-		bottom,
 	)
+	overviewHandler.BlockStatus = blockStatus
+	go func() {
+		time.Sleep(time.Millisecond * 200)
+		blockStatus.AddObject(bottom)
+		canvas.Refresh(blockStatus)
+	}()
+	return blockStatus
+}
+
+func title() fyne.CanvasObject {
+	titleWidget := widget.NewLabelWithStyle(PageTitle, fyne.TextAlignLeading, fyne.TextStyle{Bold: true, Italic: true})
+	return widget.NewHBox(titleWidget)
+}
+
+func balance() fyne.CanvasObject {
+	dcrBalance := widgets.NewLargeText("0.00", color.Black)
+	dcrDecimals := widgets.NewSmallText("00000 DCR", color.Black)
+	overviewHandler.Balance = make([]*canvas.Text, 2)
+	overviewHandler.Balance[0] = dcrBalance
+	overviewHandler.Balance[1] = dcrDecimals
+	decimalsBox := fyne.NewContainerWithLayout(layout.NewVBoxLayout(), widgets.NewVSpacer(6), dcrDecimals)
+	return widget.NewHBox(widgets.NewVSpacer(10), dcrBalance, decimalsBox)
 }
 
 func walletSyncBox(name, status, headerFetched, progress string) fyne.CanvasObject {
@@ -190,21 +196,6 @@ func walletSyncBox(name, status, headerFetched, progress string) fyne.CanvasObje
 	)
 }
 
-func newTransactionRow(transactionType, amount, fee, direction, status, date string) *widget.Box {
-	icons, _ := assets.GetIcons(assets.ReceiveIcon, assets.SendIcon)
-	icon := canvas.NewImageFromResource(icons[transactionType])
-	// spacer := widgets.NewHSpacer(10)
-	icon.SetMinSize(fyne.NewSize(5, 20))
-	iconBox := widget.NewVBox(widgets.NewVSpacer(4), icon)
-	amountLabel := widget.NewLabel(amount)
-	feeLabel := widget.NewLabel(fee)
-	dateLabel := widget.NewLabel(date)
-	statusLabel := widget.NewLabel(status)
-	directionLabel := widget.NewLabel(direction)
-	column := widget.NewHBox(iconBox, amountLabel, feeLabel, directionLabel, statusLabel, dateLabel)
-	return column
-}
-
 func transactionRowHeader() *widget.Box {
 	hash := widget.NewLabelWithStyle("#", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
 	amount := widget.NewLabelWithStyle("amount", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
@@ -213,74 +204,4 @@ func transactionRowHeader() *widget.Box {
 	status := widget.NewLabelWithStyle("status", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
 	date := widget.NewLabelWithStyle("date", fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
 	return widget.NewHBox(hash, amount, fee, direction, status, date)
-}
-
-func totalBalance(overview *overview) (balance string, err error) {
-	var totalWalletBalance int64
-	mw := overview.multiWallet
-	for _, id := range overview.walletIds {
-		accounts, err := mw.WalletWithID(id).GetAccountsRaw(dcrlibwallet.DefaultRequiredConfirmations)
-		if err != nil {
-			return "", err
-		}
-		for _, acc := range accounts.Acc {
-			totalWalletBalance += acc.TotalBalance
-		}
-	}
-	balance = dcrutil.Amount(totalWalletBalance).String()
-	return
-}
-
-func breakBalance(balance string) (b1, b2 string) {
-	balanceParts := strings.Split(balance, ".")
-	b1 = balanceParts[0]
-	if len(balanceParts) > 1 {
-		b2 = balanceParts[1]
-		b1 = b1 + "." + b2[:2]
-		b2 = b2[2:]
-	}
-	return
-}
-
-func recentTransactions(overview *overview) (transactions []dcrlibwallet.Transaction, err error) {
-	mw := overview.multiWallet
-
-	// add recent transactions of all wallets to a single slice
-	for _, id := range overview.walletIds {
-		txns, err := mw.WalletWithID(id).GetTransactionsRaw(0, 10, 0, true)
-		transactions = append(transactions, txns...)
-		if err != nil {
-			return nil, err
-		}
-	}
-	sort.SliceStable(transactions, func(i, j int) bool {
-		backTime := time.Unix(transactions[j].Timestamp, 0)
-		frontTime := time.Unix(transactions[i].Timestamp, 0)
-		return backTime.Before(frontTime)
-	})
-	if len(transactions) > 5 {
-		transactions = transactions[:5]
-	}
-	return
-}
-
-func transactionIcon(direction int32) string {
-	switch direction {
-	case 0:
-		return assets.SendIcon
-	case 1:
-		return assets.ReceiveIcon
-	case 2:
-		return assets.ReceiveIcon
-	default:
-		return assets.InfoIcon
-	}
-}
-
-func transactionStatus(overview *overview, txn dcrlibwallet.Transaction) string {
-	confirmations := overview.multiWallet.GetBestBlock().Height - txn.BlockHeight + 1
-	if txn.BlockHeight != -1 && confirmations > dcrlibwallet.DefaultRequiredConfirmations {
-		return "confirmed"
-	}
-	return "pending"
 }

--- a/fyne/pages/txnotifier.go
+++ b/fyne/pages/txnotifier.go
@@ -37,36 +37,36 @@ func (app *multiWalletTxListener) OnPeerConnectedOrDisconnected(numberOfConnecte
 func (app *multiWalletTxListener) OnHeadersFetchProgress(headersFetchProgress *dcrlibwallet.HeadersFetchProgressReport) {
 	handlers.OverviewHandlerLock.Lock()
 	defer handlers.OverviewHandlerLock.Unlock()
+	overviewHandler.Steps += 1
 	overviewHandler.SyncProgress = float64(headersFetchProgress.FetchedHeadersCount) / float64(headersFetchProgress.TotalHeadersToFetch)
 	overviewHandler.SyncProgress = math.Round(overviewHandler.SyncProgress * 100) / 100
-	overviewHandler.UpdateBlockStatusBox(app.multiWallet)
+	overviewHandler.UpdateSyncSteps(true)
+	overviewHandler.UpdateProgressBar(true)
 }
 
 func (app *multiWalletTxListener) OnAddressDiscoveryProgress(addressDiscoveryProgress *dcrlibwallet.AddressDiscoveryProgressReport) {
-
+	handlers.OverviewHandlerLock.Lock()
+	defer handlers.OverviewHandlerLock.Unlock()
+	overviewHandler.Steps += 1
+	overviewHandler.UpdateSyncSteps(true)
 }
 
 func (app *multiWalletTxListener) OnHeadersRescanProgress(headersRescanProgress *dcrlibwallet.HeadersRescanProgressReport) {
-
+	handlers.OverviewHandlerLock.Lock()
+	defer handlers.OverviewHandlerLock.Unlock()
+	overviewHandler.Steps += 1
+	overviewHandler.UpdateSyncSteps(true)
 }
 
 func (app *multiWalletTxListener) OnSyncCompleted() {
 	handlers.OverviewHandlerLock.Lock()
 	defer handlers.OverviewHandlerLock.Unlock()
-	mw := app.multiWallet
-	overviewHandler.Synced = mw.IsSynced()
-	overviewHandler.Syncing = mw.IsSyncing()
 	overviewHandler.SyncProgress = 1
-	overviewHandler.UpdateBlockStatusBox(mw)
+	overviewHandler.UpdateBlockStatusBox(app.multiWallet)
 }
 
 func (app *multiWalletTxListener) OnSyncCanceled(willRestart bool) {
-	handlers.OverviewHandlerLock.Lock()
-	defer handlers.OverviewHandlerLock.Unlock()
-	mw := app.multiWallet
-	overviewHandler.Synced = false
-	overviewHandler.Syncing = false
-	overviewHandler.UpdateBlockStatusBox(mw)
+	overviewHandler.UpdateBlockStatusBox(app.multiWallet)
 }
 
 func (app *multiWalletTxListener) OnSyncEndedWithError(err error) {

--- a/fyne/pages/txnotifier.go
+++ b/fyne/pages/txnotifier.go
@@ -6,7 +6,6 @@ import (
 	"fyne.io/fyne/widget"
 	"github.com/raedahgroup/godcr/fyne/pages/handler"
 	"log"
-	"math"
 	"strconv"
 
 	"github.com/gen2brain/beeep"
@@ -30,9 +29,8 @@ func (app *multiWalletTxListener) OnPeerConnectedOrDisconnected(numberOfConnecte
 }
 
 func (app *multiWalletTxListener) OnHeadersFetchProgress(headersFetchProgress *dcrlibwallet.HeadersFetchProgressReport) {
-	overviewHandler.SyncProgress = float64(headersFetchProgress.FetchedHeadersCount) / float64(headersFetchProgress.TotalHeadersToFetch)
-	overviewHandler.SyncProgress = math.Round(overviewHandler.SyncProgress*100) / 100
-	if headersFetchProgress.HeadersFetchProgress == 100 && overviewHandler.Steps == 0 {
+	overviewHandler.SyncProgress = float64(headersFetchProgress.TotalSyncProgress) / 100
+	if headersFetchProgress.HeadersFetchProgress == 100 && overviewHandler.Steps == 1 {
 		overviewHandler.StepsChannel <- headersFetchProgress.HeadersFetchProgress
 		overviewHandler.UpdateSyncSteps(true)
 	}

--- a/fyne/widgets/table.go
+++ b/fyne/widgets/table.go
@@ -58,9 +58,13 @@ func (table *Table) Pop() {
 	table.Refresh()
 }
 
+func (table *Table) DeleteAll() {
+	table.tableData = table.tableData[:1]
+	table.Refresh()
+}
+
 func (table *Table) Refresh() {
 	var container = widget.NewHBox()
-
 	// get horizontals apart from heading
 	for i := 0; i < len(table.heading.Children); i++ {
 		// get vertical


### PR DESCRIPTION
This PR closes #447. It adds live wallet sync details to the overview page.

<img width="648" alt="Screenshot 2019-12-26 at 10 28 45 AM" src="https://user-images.githubusercontent.com/15804688/71470280-e7dbaf80-27cb-11ea-87c1-94bf2c333629.png">

<img width="642" alt="Screenshot 2019-12-26 at 10 27 36 AM" src="https://user-images.githubusercontent.com/15804688/71470298-f7f38f00-27cb-11ea-8aeb-be73e69f69c0.png">
